### PR TITLE
fix: correct manifest.json fields to match spec

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -484,6 +484,7 @@ addon.get("/stremio/manifest.json", function (req, res) {
         resources: [],
         idPrefixes: [],
         behaviorHints: {
+          configurable: true,
           configurationRequired: false,
         },
     };

--- a/addon/index.js
+++ b/addon/index.js
@@ -483,7 +483,9 @@ addon.get("/stremio/manifest.json", function (req, res) {
         catalogs: [],
         resources: [],
         idPrefixes: [],
-        configurationRequired: true
+        behaviorHints: {
+          configurationRequired: false,
+        },
     };
     
     res.setHeader('Content-Type', 'application/json');

--- a/addon/index.js
+++ b/addon/index.js
@@ -478,7 +478,6 @@ addon.get("/stremio/manifest.json", function (req, res) {
         version: packageJson.version,
         name: "AIO Metadata",
         description: "A metadata addon for power users. AIOMetadata uses TMDB, TVDB, TVMaze, MyAnimeList, IMDB and Fanart.tv to provide accurate data for movies, series, and anime. You choose the source.",
-        favicon: `${host}/favicon.png`,
         logo: `${host}/logo.png`,
         types: ["movie", "series"],
         catalogs: [],

--- a/addon/lib/getManifest.js
+++ b/addon/lib/getManifest.js
@@ -787,7 +787,6 @@ async function getManifest(config) {
   const manifest = {
     id: packageJson.name,
     version: packageJson.version,
-    favicon: `${host}/favicon.png`,
     logo: `${host}/logo.png`,
     background: `${host}/background.png`,
     name: addonName,


### PR DESCRIPTION
If you validate your `manifest.json` you'll notice some issues:
- Missing `behaviorHints` field, to wrap the `configurationRequired` field
- The `configurable` field should be set to `true`
- The `favicon` field is unrecognized

Mainly, the missing `behaviorHints.configurable` field is the issue, because then the addon doesn't show a 'configure' button in Stremio itself nor on [stremio-addons.net](https://stremio-addons.net).

This PR addresses addresses these issues.

---

P.S. You can validate your manifest yourself [here](https://stremio-community.github.io/stremio-addon-manifest-validator/?data=N4KABGBECWAmkC4oGMD2BbAdAQ2qz6ApgC7azamQA04UAboQE4DOeAdolAIyZc8AM1WpDbYinSAEEAkgHkwAWRJkK2IREixCzZI2gAHYuwmSwRUuVJgysVGzAAzVIzD7UAdyZgArsybNMMBlZJQtVHz9mMAAVBQARACEqGIA1ROTolIVsAC9CZIUAT0k2aCIAGWhmYmTpeITrNlgwADFsUUZiTGI6MGJUV0ZUOjhCa2Rkb0YKMctsR2czYehtZL89Vcbm9rLCQIBNVG8wZAALVFQ-PtOx5iPGZD31KAdsEbQOJEhT4mJ9ZgQAHpAbgMMo5phCAAbBznaqEWCYNDoQGvd52TD6NgAc2ekChqGxqAkPz+AOBoPMKlIkJhcOICKRGEBBKJmJxeOIhX02k4AG1aBp0MtCM8NOsVsxILQALo0DTIVSsqVIPly4SMbT3R4qsBq+VQOAABU1DmgAA9ear1Qq7GbsVMKOwAEqEACO3mgmvgSGIjG8hBAAF8gA).