### PR TITLE
feat(dashboard): add ability to lock dashboard from public completely

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3426,12 +3426,64 @@ const noCache = (req, res, next) => {
   next();
 };
 
+// Middleware to require admin authentication for dashboard routes
+function requireDashboardAdmin(req, res, next) {
+  const adminKey = process.env.ADMIN_KEY;
+  
+  // If ADMIN_KEY is not configured, deny access with specific message
+  if (!adminKey) {
+    return res.status(401).json({ 
+      error: 'Unauthorized',
+      message: 'ADMIN_KEY environment variable must be configured to access the dashboard'
+    });
+  }
+  
+  // Validate the provided admin key
+  if (req.headers['x-admin-key'] !== adminKey) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  
+  // Valid key - proceed to route handler
+  next();
+}
+
+// Middleware for conditionally-protected endpoints (public when guest mode enabled)
+function requireAuthUnlessGuestMode(req, res, next) {
+  const disableGuestMode = process.env.DISABLE_GUEST_MODE === 'true' || 
+                           process.env.DISABLE_GUEST_MODE === '1';
+  
+  // If guest mode is enabled (env var not set/falsy), allow access without auth
+  if (!disableGuestMode) {
+    return next();
+  }
+  
+  // Guest mode disabled - require admin auth
+  return requireDashboardAdmin(req, res, next);
+}
+
 // Apply the no-cache middleware to all dashboard and dashboard API routes
 addon.use('/dashboard', noCache);
 addon.use('/api/dashboard', noCache);
 
+// Public config endpoint - must be defined BEFORE admin auth middleware
+// This endpoint is always accessible regardless of guest mode setting
+addon.get("/api/dashboard/config", (req, res) => {
+  try {
+    const dashboardApi = getDashboardAPI();
+    const config = dashboardApi.getConfig();
+    res.json(config);
+  } catch (error) {
+    consola.error('[Dashboard API] Error getting config:', error);
+    res.status(500).json({ error: 'Failed to fetch dashboard config' });
+  }
+});
 
-addon.get("/api/dashboard/overview", (req, res) => {
+// Note: Admin authentication is now applied per-route instead of globally
+// Public endpoints use requireAuthUnlessGuestMode (accessible without auth when guest mode enabled)
+// Protected endpoints use requireDashboardAdmin (always require admin auth)
+
+
+addon.get("/api/dashboard/overview", requireAuthUnlessGuestMode, (req, res) => {
   try {
     const dashboardApi = getDashboardAPI();
     
@@ -3477,7 +3529,7 @@ addon.get("/api/dashboard/overview", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/stats", (req, res) => {
+addon.get("/api/dashboard/stats", requireAuthUnlessGuestMode, (req, res) => {
   // Check if metrics are disabled
   if (isMetricsDisabled()) {
     return res.json({ 
@@ -3486,10 +3538,7 @@ addon.get("/api/dashboard/stats", (req, res) => {
     });
   }
   
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+  
   
   try {
     const dashboardApi = getDashboardAPI();
@@ -3509,7 +3558,7 @@ addon.get("/api/dashboard/stats", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/system", (req, res) => {
+addon.get("/api/dashboard/system", requireAuthUnlessGuestMode, (req, res) => {
   
   try {
     const dashboardApi = getDashboardAPI();
@@ -3546,11 +3595,8 @@ addon.get("/api/dashboard/system", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/operations", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.get("/api/dashboard/operations", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     const dashboardApi = getDashboardAPI();
@@ -3571,7 +3617,7 @@ addon.get("/api/dashboard/operations", (req, res) => {
 });
 
 // Enhanced timing metrics API endpoint
-addon.get("/api/dashboard/timing", async (req, res) => {
+addon.get("/api/dashboard/timing", requireAuthUnlessGuestMode, async (req, res) => {
   // Check if metrics are disabled
   if (isMetricsDisabled()) {
     return res.json({ 
@@ -3621,11 +3667,8 @@ addon.get("/api/dashboard/timing", async (req, res) => {
   }
 });
 
-addon.post("/api/dashboard/cache/clear", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/cache/clear", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     const { type } = req.body;
@@ -3646,11 +3689,8 @@ addon.post("/api/dashboard/cache/clear", (req, res) => {
   }
 });
 
-addon.post("/api/dashboard/users/clear", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/users/clear", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     const dashboardApi = getDashboardAPI();
@@ -3672,7 +3712,7 @@ addon.post("/api/dashboard/users/clear", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/analytics", async (req, res) => {
+addon.get("/api/dashboard/analytics", requireAuthUnlessGuestMode, async (req, res) => {
   // Check if metrics are disabled
   if (isMetricsDisabled()) {
     return res.json({ 
@@ -3705,11 +3745,8 @@ addon.get("/api/dashboard/analytics", async (req, res) => {
   }
 });
 
-addon.post("/api/dashboard/uptime/reset", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/uptime/reset", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     // Reset the persistent uptime counter
@@ -3730,11 +3767,8 @@ addon.post("/api/dashboard/uptime/reset", (req, res) => {
 });
 
 // Test endpoint to generate sample error logs
-addon.post("/api/dashboard/test-errors", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/test-errors", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     // Generate some test error logs
@@ -3764,7 +3798,7 @@ addon.post("/api/dashboard/test-errors", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/content", (req, res) => {
+addon.get("/api/dashboard/content", requireAuthUnlessGuestMode, (req, res) => {
   // Check if metrics are disabled
   if (isMetricsDisabled()) {
     return res.json({ 
@@ -3800,14 +3834,10 @@ addon.get("/api/dashboard/content", (req, res) => {
   }
 });
 
-addon.get("/api/dashboard/users", (req, res) => {
+addon.get("/api/dashboard/users", requireDashboardAdmin, (req, res) => {
   // Users endpoint is NOT disabled when metrics are disabled
   // It provides user management which is essential for admin UI
   
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
   
   try {
     const dashboardApi = getDashboardAPI();
@@ -3824,7 +3854,7 @@ addon.get("/api/dashboard/users", (req, res) => {
 });
 
 // MAL Catalog Warmup Stats endpoint
-addon.get("/api/dashboard/mal-warmup", (req, res) => {
+addon.get("/api/dashboard/mal-warmup", requireAuthUnlessGuestMode, (req, res) => {
   try {
     const { getWarmupStats } = require('./lib/malCatalogWarmer');
     const stats = getWarmupStats();
@@ -3836,7 +3866,7 @@ addon.get("/api/dashboard/mal-warmup", (req, res) => {
 });
 
 // Comprehensive Catalog Warmup Stats endpoint
-addon.get("/api/dashboard/catalog-warmup", (req, res) => {
+addon.get("/api/dashboard/catalog-warmup", requireAuthUnlessGuestMode, (req, res) => {
   try {
     const { getWarmupStats } = require('./lib/comprehensiveCatalogWarmer');
     const stats = getWarmupStats();
@@ -3848,7 +3878,7 @@ addon.get("/api/dashboard/catalog-warmup", (req, res) => {
 });
 
 // Comprehensive Warming Dashboard - combines all warming systems
-addon.get("/api/dashboard/warming", (req, res) => {
+addon.get("/api/dashboard/warming", requireAuthUnlessGuestMode, (req, res) => {
   try {
     // Get stats from all warming systems
     const { getWarmupStats: getMALStats } = require('./lib/malCatalogWarmer');
@@ -3893,11 +3923,8 @@ addon.get("/api/dashboard/warming", (req, res) => {
 });
 
 // Warming Control Endpoints
-addon.post("/api/dashboard/warming/control", (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/warming/control", requireDashboardAdmin, (req, res) => {
+  
   
   try {
     const { action, system } = req.body;
@@ -3953,11 +3980,8 @@ addon.post("/api/dashboard/warming/control", (req, res) => {
 });
 
 // Maintenance Task Execution endpoint
-addon.post("/api/dashboard/maintenance/execute", async (req, res) => {
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey && req.headers['x-admin-key'] !== adminKey) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+addon.post("/api/dashboard/maintenance/execute", requireDashboardAdmin, async (req, res) => {
+  
   
   try {
     const { taskId, action } = req.body;

--- a/addon/lib/dashboardApi.js
+++ b/addon/lib/dashboardApi.js
@@ -1922,6 +1922,16 @@ class DashboardAPI {
     if (diffMins < 60) return "idle";
     return "offline";
   }
+
+  // Get dashboard configuration for guest mode and admin key status
+  getConfig() {
+    const disableGuestMode = process.env.DISABLE_GUEST_MODE === 'true' || 
+                             process.env.DISABLE_GUEST_MODE === '1';
+    return {
+      guestModeEnabled: !disableGuestMode,
+      adminKeyConfigured: !!process.env.ADMIN_KEY
+    };
+  }
 }
 
 module.exports = DashboardAPI;

--- a/addon/lib/requestTracker.js
+++ b/addon/lib/requestTracker.js
@@ -470,7 +470,7 @@ class RequestTracker {
                 title: metadata.title,
                 rating: metadata.rating,
                 year: metadata.year,
-                poster: metadata.poster,
+                // poster: metadata.poster, // Not used in dashboard UI
                 imdb_id: metadata.imdb_id,
               };
             }

--- a/configure/src/components/Dashboard.tsx
+++ b/configure/src/components/Dashboard.tsx
@@ -704,6 +704,7 @@ function DashboardAnalytics({ data, loading }) {
 
 // Performance Metrics Component
 function DashboardPerformance({ data, loading }) {
+  const { adminKey, isAdmin, isGuest } = useAdmin();
   const [timingMetrics, setTimingMetrics] = useState({});
   const [selectedMetric, setSelectedMetric] = useState("id_resolution_total");
   const [timeRange, setTimeRange] = useState("24h");
@@ -731,10 +732,23 @@ function DashboardPerformance({ data, loading }) {
   }, [data]);
 
   useEffect(() => {
+    // Only fetch if authenticated (either admin or guest)
+    if (!isAdmin && !isGuest) {
+      return;
+    }
+
     // Fetch ID resolver performance data
     const fetchIdResolverPerformance = async () => {
       try {
-        const response = await fetch("/api/dashboard/analytics");
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+        // Only include admin key for admin users
+        if (isAdmin && adminKey) {
+          headers['x-admin-key'] = adminKey;
+        }
+
+        const response = await fetch("/api/dashboard/analytics", { headers });
         if (response.ok) {
           const analyticsData = await response.json();
           if (analyticsData.idResolverPerformance) {
@@ -747,7 +761,7 @@ function DashboardPerformance({ data, loading }) {
     };
 
     fetchIdResolverPerformance();
-  }, []);
+  }, [isAdmin, isGuest, adminKey]);
 
   const formatDuration = (ms) => {
     if (ms < 1000) return `${ms}ms`;
@@ -1614,6 +1628,7 @@ function DashboardPerformance({ data, loading }) {
 
 // Content Intelligence Component
 function DashboardContent({ data, loading }) {
+  const { adminKey, isAdmin, isGuest } = useAdmin();
   const [popularContent, setPopularContent] = useState([]);
   const [searchPatterns, setSearchPatterns] = useState([]);
   const [searchLimit, setSearchLimit] = useState(10);
@@ -1625,11 +1640,25 @@ function DashboardContent({ data, loading }) {
   });
 
   useEffect(() => {
+    // Only fetch if authenticated (either admin or guest)
+    if (!isAdmin && !isGuest) {
+      return;
+    }
+
     // Fetch real content data
     const fetchContentData = async () => {
       try {
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+        // Only include admin key for admin users
+        if (isAdmin && adminKey) {
+          headers['x-admin-key'] = adminKey;
+        }
+
         const response = await fetch(
           `/api/dashboard/content?limit=${searchLimit}`,
+          { headers }
         );
         if (response.ok) {
           const data = await response.json();
@@ -1652,7 +1681,7 @@ function DashboardContent({ data, loading }) {
     };
 
     fetchContentData();
-  }, [searchLimit]);
+  }, [searchLimit, isAdmin, isGuest, adminKey]);
 
   return (
     <div className="space-y-6">
@@ -1779,7 +1808,7 @@ function DashboardContent({ data, loading }) {
         </CardContent>
       </Card>
 
-      {/* Content Quality Metrics */}
+      {/* Content Quality Metrics - Placeholder, hidden for now
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
@@ -1835,8 +1864,9 @@ function DashboardContent({ data, loading }) {
           </CardContent>
         </Card>
       </div>
+      */}
 
-      {/* Content Trends Placeholder */}
+      {/* Content Trends Placeholder - Hidden for now
       <Card>
         <CardHeader>
           <CardTitle>Content Trends</CardTitle>
@@ -1854,6 +1884,7 @@ function DashboardContent({ data, loading }) {
           </div>
         </CardContent>
       </Card>
+      */}
     </div>
   );
 }
@@ -3062,7 +3093,7 @@ function DashboardUsers({ data, loading }) {
         </CardContent>
       </Card>
 
-      {/* Access Control */}
+      {/* Access Control - Placeholder, hidden for now
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
@@ -3100,6 +3131,7 @@ function DashboardUsers({ data, loading }) {
             </div>
           </CardContent>
         </Card>
+        */}
 
         <Card>
           <CardHeader>
@@ -3118,6 +3150,7 @@ function DashboardUsers({ data, loading }) {
                 <Users className="h-4 w-4 mr-2" />
                 Manage Users
               </Button>
+              {/* Placeholder buttons - hidden for now
               <Button variant="outline" className="w-full">
                 <Shield className="h-4 w-4 mr-2" />
                 Access Control
@@ -3130,6 +3163,7 @@ function DashboardUsers({ data, loading }) {
                 <Settings className="h-4 w-4 mr-2" />
                 User Settings
               </Button>
+              */}
               <Button 
                 variant="destructive" 
                 className="w-full"
@@ -3149,9 +3183,11 @@ function DashboardUsers({ data, loading }) {
             </div>
           </CardContent>
         </Card>
+      {/* Closing div for Access Control grid - commented out
       </div>
+      */}
 
-      {/* User Analytics Placeholder */}
+      {/* User Analytics Placeholder - Hidden for now
       <Card>
         <CardHeader>
           <CardTitle>User Analytics</CardTitle>
@@ -3167,6 +3203,7 @@ function DashboardUsers({ data, loading }) {
           </div>
         </CardContent>
       </Card>
+      */}
 
       {/* User Activity Details Dialog */}
       <Dialog open={showUserDetails} onOpenChange={setShowUserDetails}>
@@ -3264,40 +3301,28 @@ function DashboardUsers({ data, loading }) {
   );
 }
 
-// Admin Login Component
-function AdminLogin() {
-  const {
-    isAdmin,
-    adminKey: contextAdminKey,
-    login,
-    logout,
-    isLoading,
-  } = useAdmin();
+// Blocking Admin Login Modal Component
+interface AdminLoginModalProps {
+  isOpen: boolean;
+  onSuccess: () => void;
+  onGuestSuccess: () => void;
+  onCancel: () => void;
+  adminKeyNotConfigured?: boolean;
+  guestModeEnabled?: boolean;
+}
+
+function AdminLoginModal({ 
+  isOpen, 
+  onSuccess, 
+  onGuestSuccess,
+  onCancel, 
+  adminKeyNotConfigured,
+  guestModeEnabled 
+}: AdminLoginModalProps) {
+  const { login, loginAsGuest, isLoading } = useAdmin();
   const [inputAdminKey, setInputAdminKey] = useState("");
-  const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState("");
-  const [adminFeaturesAvailable, setAdminFeaturesAvailable] = useState(true);
-
-  // Check if admin features are available on mount
-  useEffect(() => {
-    const checkAdminFeatures = async () => {
-      try {
-        const response = await fetch("/api/dashboard/users", {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-        // If it returns 401, admin features are available but require authentication
-        // If it returns 200, admin features are disabled (no ADMIN_KEY set)
-        setAdminFeaturesAvailable(response.status === 401);
-      } catch (error) {
-        setAdminFeaturesAvailable(false);
-      }
-    };
-
-    checkAdminFeatures();
-  }, []);
+  const [showAdminInput, setShowAdminInput] = useState(false);
 
   const handleLogin = async () => {
     if (!inputAdminKey.trim()) {
@@ -3305,81 +3330,190 @@ function AdminLogin() {
       return;
     }
 
+    setError("");
     const success = await login(inputAdminKey);
     if (success) {
       setInputAdminKey("");
       setError("");
-      setIsOpen(false);
+      setShowAdminInput(false);
+      onSuccess();
     } else {
-      setError("Invalid admin key");
+      setError("Invalid admin key. Please try again.");
     }
   };
 
-  const handleLogout = () => {
-    logout();
-    setIsOpen(false);
+  const handleGuestLogin = () => {
+    loginAsGuest();
+    onGuestSuccess();
   };
 
-  if (isAdmin) {
+  const handleGoBack = () => {
+    // Navigate away from dashboard 
+    const stored = sessionStorage.getItem('lastConfigureUrl');
+    window.location.href = stored || '/configure';
+  };
+
+  const handleBackToOptions = () => {
+    setShowAdminInput(false);
+    setInputAdminKey("");
+    setError("");
+  };
+
+  // Show specific message when ADMIN_KEY is not configured AND guest mode is disabled
+  if (adminKeyNotConfigured && !guestModeEnabled) {
     return (
-      <div className="flex items-center gap-2">
-        <Badge variant="default" className="bg-green-600">
-          <Shield className="h-3 w-3 mr-1" />
-          Admin
-        </Badge>
-        {contextAdminKey && (
-          <Button variant="outline" size="sm" onClick={handleLogout}>
-            <LogOut className="h-4 w-4 mr-1" />
-            Logout
-          </Button>
-        )}
-      </div>
+      <Dialog open={isOpen} onOpenChange={() => {}}>
+        <DialogContent 
+          className="sm:max-w-md mx-4" 
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertCircle className="h-5 w-5 text-amber-500" />
+              Dashboard Access Unavailable
+            </DialogTitle>
+            <DialogDescription>
+              Dashboard access requires the ADMIN_KEY environment variable to be configured on the server.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="p-3 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md text-sm text-amber-700 dark:text-amber-300">
+              <p className="font-medium mb-1">Configuration Required</p>
+              <p>Please set the ADMIN_KEY environment variable on your server to enable dashboard access.</p>
+            </div>
+            <div className="flex justify-end">
+              <Button variant="outline" onClick={handleGoBack}>
+                Go Back
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     );
   }
 
-  // If admin features are not available, don't show anything
-  if (!adminFeaturesAvailable) {
-    return null;
+  // Show admin login input when "Admin Login" is clicked
+  if (showAdminInput) {
+    return (
+      <Dialog open={isOpen} onOpenChange={() => {}}>
+        <DialogContent 
+          className="sm:max-w-md mx-4"
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Shield className="h-5 w-5" />
+              Admin Authentication
+            </DialogTitle>
+            <DialogDescription>
+              Enter your admin key to access all dashboard features.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-md text-sm text-red-700 dark:text-red-300">
+                {error}
+              </div>
+            )}
+            {/* Show warning if ADMIN_KEY is not configured but guest mode is enabled */}
+            {adminKeyNotConfigured && guestModeEnabled && (
+              <div className="p-3 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md text-sm text-amber-700 dark:text-amber-300">
+                <p className="font-medium mb-1">Admin Access Unavailable</p>
+                <p>ADMIN_KEY is not configured on the server. You can continue as a guest to view public metrics.</p>
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="admin-key-modal">Admin Key</Label>
+              <Input
+                id="admin-key-modal"
+                type="password"
+                value={inputAdminKey}
+                onChange={(e) => setInputAdminKey(e.target.value)}
+                placeholder="Enter admin key"
+                onKeyDown={(e) => e.key === "Enter" && handleLogin()}
+                autoFocus
+                disabled={adminKeyNotConfigured}
+              />
+            </div>
+            <div className="flex justify-between gap-2">
+              <Button variant="outline" onClick={handleBackToOptions}>
+                Back
+              </Button>
+              <Button onClick={handleLogin} disabled={isLoading || adminKeyNotConfigured}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Authenticating...
+                  </>
+                ) : (
+                  "Login"
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
   }
 
+  // Show login options: Admin Login and Guest (if enabled)
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          <Key className="h-4 w-4 mr-1" />
-          Admin Login
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md mx-4">
+    <Dialog open={isOpen} onOpenChange={() => {}}>
+      <DialogContent 
+        className="sm:max-w-md mx-4"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
-          <DialogTitle>Admin Authentication</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            Dashboard Access
+          </DialogTitle>
           <DialogDescription>
-            Enter your admin key to access administrative features.
+            {guestModeEnabled 
+              ? "Choose how you'd like to access the dashboard."
+              : "Enter your admin key to access the dashboard."
+            }
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
-          {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
-              {error}
+          {/* Admin Login Option */}
+          <Button 
+            className="w-full justify-start h-auto py-4" 
+            variant="outline"
+            onClick={() => setShowAdminInput(true)}
+          >
+            <div className="flex items-center gap-3">
+              <Key className="h-5 w-5 text-primary" />
+              <div className="text-left">
+                <p className="font-medium">Admin Login</p>
+                <p className="text-xs text-muted-foreground">Full access to all dashboard features</p>
+              </div>
             </div>
-          )}
-          <div className="space-y-2">
-            <Label htmlFor="admin-key">Admin Key</Label>
-            <Input
-              id="admin-key"
-              type="password"
-              value={inputAdminKey}
-              onChange={(e) => setInputAdminKey(e.target.value)}
-              placeholder="Enter admin key"
-              onKeyDown={(e) => e.key === "Enter" && handleLogin()}
-            />
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setIsOpen(false)}>
-              Cancel
+          </Button>
+
+          {/* Guest Option - Only shown when guest mode is enabled */}
+          {guestModeEnabled && (
+            <Button 
+              className="w-full justify-start h-auto py-4" 
+              variant="outline"
+              onClick={handleGuestLogin}
+            >
+              <div className="flex items-center gap-3">
+                <Users className="h-5 w-5 text-muted-foreground" />
+                <div className="text-left">
+                  <p className="font-medium">Continue as Guest</p>
+                  <p className="text-xs text-muted-foreground">View public metrics without authentication</p>
+                </div>
+              </div>
             </Button>
-            <Button onClick={handleLogin} disabled={isLoading}>
-              {isLoading ? "Authenticating..." : "Login"}
+          )}
+
+          <div className="flex justify-start pt-2">
+            <Button variant="ghost" size="sm" onClick={handleGoBack}>
+              Go Back
             </Button>
           </div>
         </div>
@@ -3388,10 +3522,56 @@ function AdminLogin() {
   );
 }
 
+// Access level type for tracking current user access
+type AccessLevel = 'none' | 'guest' | 'admin';
+
+// Admin Status Badge Component - Shows admin/guest status and logout button when authenticated
+function AdminStatusBadge() {
+  const { isAdmin, isGuest, adminKey, logout } = useAdmin();
+
+  // Determine current access level based on AdminContext state
+  const accessLevel: AccessLevel = isAdmin ? 'admin' : isGuest ? 'guest' : 'none';
+
+  const handleLogout = () => {
+    logout();
+  };
+
+  // Don't show badge if not authenticated
+  if (accessLevel === 'none') {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {accessLevel === 'admin' ? (
+        <Badge variant="default" className="bg-green-600">
+          <Shield className="h-3 w-3 mr-1" />
+          Admin
+        </Badge>
+      ) : (
+        <Badge variant="secondary" className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+          <Users className="h-3 w-3 mr-1" />
+          Guest
+        </Badge>
+      )}
+      {(adminKey || isGuest) && (
+        <Button variant="outline" size="sm" onClick={handleLogout}>
+          <LogOut className="h-4 w-4 mr-1" />
+          Logout
+        </Button>
+      )}
+    </div>
+  );
+}
+
 // Main Dashboard Component
 export function Dashboard() {
-  const { isAdmin, adminKey } = useAdmin();
+  const { isAdmin, isGuest, adminKey, isLoading, adminKeyConfigured, guestModeEnabled } = useAdmin();
   const { isMobile } = useBreakpoint();
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  // Access level state management - tracks current access level based on AdminContext state
+  const accessLevel: AccessLevel = isAdmin ? 'admin' : isGuest ? 'guest' : 'none';
 
   // Unified dashboard data state
   const [dashboardData, setDashboardData] = useState({
@@ -3408,75 +3588,103 @@ export function Dashboard() {
 
   // Unified data fetching - fetch all dashboard data once
   useEffect(() => {
+    // Don't fetch data if not authenticated (neither admin nor guest)
+    if (!isAdmin && !isGuest) {
+      setDashboardData((prev) => ({ ...prev, loading: false }));
+      return;
+    }
+
     const fetchAllDashboardData = async () => {
       try {
         setDashboardData((prev) => ({ ...prev, loading: true, error: null }));
 
-        // Fetch all dashboard data in parallel
-        const [
-          overviewResponse,
-          analyticsResponse,
-          contentResponse,
-          performanceResponse,
-          systemResponse,
-        ] = await Promise.all([
-          fetch("/api/dashboard/overview"),
-          fetch("/api/dashboard/analytics"),
-          fetch("/api/dashboard/content"),
-          fetch("/api/dashboard/timing"),
-          fetch("/api/dashboard/system"),
-        ]);
-
-        const data = {
-          overview: overviewResponse.ok ? await overviewResponse.json() : null,
-          analytics: analyticsResponse.ok
-            ? await analyticsResponse.json()
-            : null,
-          content: contentResponse.ok ? await contentResponse.json() : null,
-          performance: performanceResponse.ok
-            ? await performanceResponse.json()
-            : null,
-          system: systemResponse.ok ? await systemResponse.json() : null,
-          operations: null,
-          users: null,
-        };
-
-        // Fetch admin-only data if admin is logged in
+        const headers: Record<string, string> = {};
+        
+        // Only add admin key header for admin users
         if (isAdmin && adminKey) {
-          console.log(
-            "[Dashboard] Fetching admin data with key:",
-            adminKey ? "present" : "missing",
-          );
-          const headers = { "x-admin-key": adminKey };
-          const [operationsResponse, usersResponse] = await Promise.all([
+          headers["x-admin-key"] = adminKey;
+        }
+
+        // For guest users, only fetch public endpoints
+        // For admin users, fetch all endpoints
+        if (isGuest) {
+          // Guest mode: fetch only public endpoints without auth
+          const [
+            overviewResponse,
+            analyticsResponse,
+            contentResponse,
+            performanceResponse,
+            systemResponse,
+          ] = await Promise.all([
+            fetch("/api/dashboard/overview"),
+            fetch("/api/dashboard/analytics"),
+            fetch("/api/dashboard/content"),
+            fetch("/api/dashboard/timing"),
+            fetch("/api/dashboard/system"),
+          ]);
+
+          const data = {
+            overview: overviewResponse.ok ? await overviewResponse.json() : null,
+            analytics: analyticsResponse.ok ? await analyticsResponse.json() : null,
+            content: contentResponse.ok ? await contentResponse.json() : null,
+            performance: performanceResponse.ok ? await performanceResponse.json() : null,
+            system: systemResponse.ok ? await systemResponse.json() : null,
+            operations: null, // Not available for guests
+            users: null, // Not available for guests
+          };
+
+          setDashboardData({
+            ...data,
+            loading: false,
+            error: null,
+          });
+        } else {
+          // Admin mode: fetch all endpoints with authentication
+          const [
+            overviewResponse,
+            analyticsResponse,
+            contentResponse,
+            performanceResponse,
+            systemResponse,
+            operationsResponse,
+            usersResponse,
+          ] = await Promise.all([
+            fetch("/api/dashboard/overview", { headers }),
+            fetch("/api/dashboard/analytics", { headers }),
+            fetch("/api/dashboard/content", { headers }),
+            fetch("/api/dashboard/timing", { headers }),
+            fetch("/api/dashboard/system", { headers }),
             fetch("/api/dashboard/operations", { headers }),
             fetch("/api/dashboard/users", { headers }),
           ]);
 
-          console.log(
-            "[Dashboard] Operations response:",
-            operationsResponse.status,
-          );
-          console.log("[Dashboard] Users response:", usersResponse.status);
+          // Check for 401 responses - trigger re-authentication if needed
+          const responses = [overviewResponse, analyticsResponse, contentResponse, performanceResponse, systemResponse];
+          const hasUnauthorized = responses.some(r => r.status === 401);
+          
+          if (hasUnauthorized) {
+            // Session may have expired, show login modal
+            setShowLoginModal(true);
+            setDashboardData((prev) => ({ ...prev, loading: false }));
+            return;
+          }
 
-          data.operations = operationsResponse.ok
-            ? await operationsResponse.json()
-            : null;
-          data.users = usersResponse.ok ? await usersResponse.json() : null;
-        } else {
-          console.log(
-            "[Dashboard] Not fetching admin data - isAdmin:",
-            isAdmin,
-            "adminKey:",
-            adminKey ? "present" : "missing",
-          );
+          const data = {
+            overview: overviewResponse.ok ? await overviewResponse.json() : null,
+            analytics: analyticsResponse.ok ? await analyticsResponse.json() : null,
+            content: contentResponse.ok ? await contentResponse.json() : null,
+            performance: performanceResponse.ok ? await performanceResponse.json() : null,
+            system: systemResponse.ok ? await systemResponse.json() : null,
+            operations: operationsResponse.ok ? await operationsResponse.json() : null,
+            users: usersResponse.ok ? await usersResponse.json() : null,
+          };
+
+          setDashboardData({
+            ...data,
+            loading: false,
+            error: null,
+          });
         }
-
-        setDashboardData({
-          ...data,
-          loading: false,
-          error: null,
-        });
       } catch (error) {
         console.error("Failed to fetch dashboard data:", error);
         setDashboardData((prev) => ({
@@ -3488,12 +3696,65 @@ export function Dashboard() {
     };
 
     fetchAllDashboardData();
-  }, [isAdmin, adminKey]); // Re-fetch when admin status changes
+  }, [isAdmin, isGuest, adminKey]); // Re-fetch when admin/guest status changes
+
+  // Show login modal when not authenticated (neither admin nor guest)
+  useEffect(() => {
+    if (!isLoading && !isAdmin && !isGuest) {
+      setShowLoginModal(true);
+    } else if (isAdmin || isGuest) {
+      setShowLoginModal(false);
+    }
+  }, [isLoading, isAdmin, isGuest]);
+
+  // Handle successful admin login
+  const handleLoginSuccess = () => {
+    setShowLoginModal(false);
+  };
+
+  // Handle successful guest login
+  const handleGuestSuccess = () => {
+    setShowLoginModal(false);
+  };
+
+  // Handle login cancel (go back)
+  const handleLoginCancel = () => {
+    const stored = sessionStorage.getItem('lastConfigureUrl');
+    window.location.href = stored || '/configure';
+  };
+
+  // Show loading state while checking authentication (only on initial load)
+  // Don't show loading spinner during login attempts - keep the modal visible
+  if (isLoading && !showLoginModal) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Checking authentication...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show login modal if not authenticated (neither admin nor guest)
+  // Don't render any dashboard content behind the modal
+  if (!isAdmin && !isGuest) {
+    return (
+      <AdminLoginModal
+        isOpen={showLoginModal}
+        onSuccess={handleLoginSuccess}
+        onGuestSuccess={handleGuestSuccess}
+        onCancel={handleLoginCancel}
+        adminKeyNotConfigured={!adminKeyConfigured}
+        guestModeEnabled={guestModeEnabled}
+      />
+    );
+  }
 
   // Calculate grid columns based on admin status
   const gridCols = isAdmin ? "grid-cols-6" : "grid-cols-4";
 
-  // Dashboard pages configuration
+  // Dashboard pages configuration - base pages available to all authenticated users
   const dashboardPages = [
     {
       value: "overview",
@@ -3548,8 +3809,7 @@ export function Dashboard() {
     },
   ];
 
-  // Add admin-only pages
-  if (isAdmin) {
+  if (accessLevel === 'admin') {
     dashboardPages.push(
       {
         value: "operations",
@@ -3585,7 +3845,7 @@ export function Dashboard() {
               Monitor your addon's performance, health, and usage statistics
             </p>
           </div>
-          <AdminLogin />
+          <AdminStatusBadge />
         </div>
 
 
@@ -3623,7 +3883,7 @@ export function Dashboard() {
             Monitor your addon's performance, health, and usage statistics
           </p>
         </div>
-        <AdminLogin />
+        <AdminStatusBadge />
       </div>
 
       {/* Metrics Disabled Banner */}
@@ -3668,21 +3928,22 @@ export function Dashboard() {
           >
             System
           </TabsTrigger>
-          {isAdmin && (
-            <TabsTrigger
-              value="operations"
-              className="text-xs sm:text-sm whitespace-nowrap"
-            >
-              Ops
-            </TabsTrigger>
-          )}
-          {isAdmin && (
-            <TabsTrigger
-              value="users"
-              className="text-xs sm:text-sm whitespace-nowrap"
-            >
-              Users
-            </TabsTrigger>
+          {/* Ops and Users tabs only visible for admin users */}
+          {accessLevel === 'admin' && (
+            <>
+              <TabsTrigger
+                value="operations"
+                className="text-xs sm:text-sm whitespace-nowrap"
+              >
+                Ops
+              </TabsTrigger>
+              <TabsTrigger
+                value="users"
+                className="text-xs sm:text-sm whitespace-nowrap"
+              >
+                Users
+              </TabsTrigger>
+            </>
           )}
         </TabsList>
 
@@ -3722,22 +3983,23 @@ export function Dashboard() {
           />
         </TabsContent>
 
-        {isAdmin && (
-          <TabsContent value="operations" className="mt-6">
-            <DashboardOperations
-              data={dashboardData.operations}
-              loading={dashboardData.loading}
-            />
-          </TabsContent>
-        )}
+        {/* Ops and Users tab content only rendered for admin users */}
+        {accessLevel === 'admin' && (
+          <>
+            <TabsContent value="operations" className="mt-6">
+              <DashboardOperations
+                data={dashboardData.operations}
+                loading={dashboardData.loading}
+              />
+            </TabsContent>
 
-        {isAdmin && (
-          <TabsContent value="users" className="mt-6">
-            <DashboardUsers
-              data={dashboardData.users}
-              loading={dashboardData.loading}
-            />
-          </TabsContent>
+            <TabsContent value="users" className="mt-6">
+              <DashboardUsers
+                data={dashboardData.users}
+                loading={dashboardData.loading}
+              />
+            </TabsContent>
+          </>
         )}
       </Tabs>
     </div>

--- a/configure/src/contexts/AdminContext.tsx
+++ b/configure/src/contexts/AdminContext.tsx
@@ -2,24 +2,61 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 
 interface AdminContextType {
   isAdmin: boolean;
+  isGuest: boolean;
   adminKey: string | null;
   login: (key: string) => Promise<boolean>;
+  loginAsGuest: () => void;
   logout: () => void;
   isLoading: boolean;
+  adminKeyConfigured: boolean;  // Indicates if ADMIN_KEY is set on server
+  guestModeEnabled: boolean;    // Indicates if guest mode is available
 }
 
 const AdminContext = createContext<AdminContextType | undefined>(undefined);
 
 const ADMIN_KEY_STORAGE = 'admin-key';
 const ADMIN_SESSION_STORAGE = 'admin-session';
+const GUEST_SESSION_STORAGE = 'guest-session';
+
+// Message returned by backend when ADMIN_KEY is not configured
+const ADMIN_KEY_NOT_CONFIGURED_MESSAGE = 'ADMIN_KEY environment variable must be configured to access the dashboard';
 
 export function AdminProvider({ children }: { children: React.ReactNode }) {
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isGuest, setIsGuest] = useState(false);
   const [adminKey, setAdminKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [adminKeyConfigured, setAdminKeyConfigured] = useState(true);  // Assume configured until proven otherwise
+  const [guestModeEnabled, setGuestModeEnabled] = useState(false);     // Guest mode disabled by default
 
-  // Check if admin features are available (ADMIN_KEY is set and working)
-  const checkAdminFeaturesAvailable = async (): Promise<boolean> => {
+  // Fetch dashboard config to determine guest mode availability
+  const fetchDashboardConfig = async (): Promise<{ guestModeEnabled: boolean; adminKeyConfigured: boolean }> => {
+    try {
+      const response = await fetch('/api/dashboard/config', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        return {
+          guestModeEnabled: data.guestModeEnabled ?? false,
+          adminKeyConfigured: data.adminKeyConfigured ?? true
+        };
+      }
+      
+      // If config endpoint fails, fall back to defaults
+      return { guestModeEnabled: false, adminKeyConfigured: true };
+    } catch (error) {
+      console.error('Error fetching dashboard config:', error);
+      return { guestModeEnabled: false, adminKeyConfigured: true };
+    }
+  };
+
+  // Check if admin features are available
+  const checkAdminFeaturesAvailable = async (): Promise<{ available: boolean; configured: boolean }> => {
     try {
       // Try to access an admin-only endpoint to see if ADMIN_KEY is set
       const response = await fetch('/api/dashboard/users', {
@@ -28,11 +65,26 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
           'Content-Type': 'application/json'
         }
       });
-      // If it returns 401, admin features are available but require authentication
+      
+      if (response.status === 401) {
+        // Check if the 401 is due to ADMIN_KEY not being configured
+        try {
+          const data = await response.json();
+          if (data.message && data.message.includes('ADMIN_KEY environment variable must be configured')) {
+            // ADMIN_KEY is not configured on the server
+            return { available: false, configured: false };
+          }
+        } catch {
+          // If we can't parse JSON, assume it's a normal auth failure
+        }
+        // Normal 401 - admin features are available and require authentication
+        return { available: true, configured: true };
+      }
+      
       // If it returns 200, admin features are disabled (no ADMIN_KEY set)
-      return response.status === 401;
+      return { available: false, configured: false };
     } catch (error) {
-      return false;
+      return { available: false, configured: true };  // Network error, assume configured
     }
   };
 
@@ -40,10 +92,32 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const checkExistingSession = async () => {
       try {
-        // First check if admin features are available (ADMIN_KEY is set)
-        const adminFeaturesAvailable = await checkAdminFeaturesAvailable();
+        // First fetch dashboard config to determine guest mode availability
+        const config = await fetchDashboardConfig();
+        setGuestModeEnabled(config.guestModeEnabled);
+        setAdminKeyConfigured(config.adminKeyConfigured);
+
+        // Check for existing guest session
+        const guestSession = sessionStorage.getItem(GUEST_SESSION_STORAGE);
+        if (guestSession === 'true' && config.guestModeEnabled) {
+          // Restore guest session
+          setIsGuest(true);
+          setIsAdmin(false);
+          setAdminKey(null);
+          setIsLoading(false);
+          return;
+        }
+
+        // Check if admin features are available (ADMIN_KEY is set)
+        const { available: adminFeaturesAvailable, configured } = await checkAdminFeaturesAvailable();
+        
+        // Update the adminKeyConfigured state if different from config
+        if (!configured) {
+          setAdminKeyConfigured(false);
+        }
+        
         if (!adminFeaturesAvailable) {
-          // Admin features are disabled (no ADMIN_KEY set)
+          // Admin features are disabled (no ADMIN_KEY set or not configured)
           setIsAdmin(false);
           setAdminKey(null);
           setIsLoading(false);
@@ -56,7 +130,13 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
         
         if (storedKey && sessionActive) {
           // Verify the key is still valid
-          const isValid = await verifyAdminKey(storedKey);
+          const { valid: isValid, configured } = await verifyAdminKey(storedKey);
+          
+          // Update adminKeyConfigured state if we detect it's not configured
+          if (!configured) {
+            setAdminKeyConfigured(false);
+          }
+          
           if (isValid) {
             setAdminKey(storedKey);
             setIsAdmin(true);
@@ -71,6 +151,7 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
         // Clear any invalid session data
         sessionStorage.removeItem(ADMIN_KEY_STORAGE);
         sessionStorage.removeItem(ADMIN_SESSION_STORAGE);
+        sessionStorage.removeItem(GUEST_SESSION_STORAGE);
       } finally {
         setIsLoading(false);
       }
@@ -79,7 +160,8 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
     checkExistingSession();
   }, []);
 
-  const verifyAdminKey = async (key: string): Promise<boolean> => {
+  // Verify admin key and return result with configuration status
+  const verifyAdminKey = async (key: string): Promise<{ valid: boolean; configured: boolean }> => {
     try {
       // Try with the provided admin key on an admin-only endpoint
       const responseWithKey = await fetch('/api/dashboard/users', {
@@ -90,17 +172,40 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
         }
       });
       
-      return responseWithKey.ok;
+      if (responseWithKey.ok) {
+        return { valid: true, configured: true };
+      }
+      
+      // Check if the 401 is due to ADMIN_KEY not being configured
+      if (responseWithKey.status === 401) {
+        try {
+          const data = await responseWithKey.json();
+          if (data.message && data.message.includes(ADMIN_KEY_NOT_CONFIGURED_MESSAGE)) {
+            // ADMIN_KEY is not configured on the server
+            return { valid: false, configured: false };
+          }
+        } catch {
+          // If we can't parse JSON, assume it's a normal auth failure
+        }
+      }
+      
+      return { valid: false, configured: true };
     } catch (error) {
       console.error('Error verifying admin key:', error);
-      return false;
+      return { valid: false, configured: true };  // Network error, assume configured
     }
   };
 
   const login = async (key: string): Promise<boolean> => {
     try {
       setIsLoading(true);
-      const isValid = await verifyAdminKey(key);
+      const { valid: isValid, configured } = await verifyAdminKey(key);
+      
+      // Update adminKeyConfigured state based on response
+      if (!configured) {
+        setAdminKeyConfigured(false);
+        return false;
+      }
       
       if (isValid) {
         setAdminKey(key);
@@ -122,16 +227,37 @@ export function AdminProvider({ children }: { children: React.ReactNode }) {
   const logout = () => {
     setAdminKey(null);
     setIsAdmin(false);
+    setIsGuest(false);
+    sessionStorage.removeItem(ADMIN_KEY_STORAGE);
+    sessionStorage.removeItem(ADMIN_SESSION_STORAGE);
+    sessionStorage.removeItem(GUEST_SESSION_STORAGE);
+  };
+
+  const loginAsGuest = () => {
+    // Only allow guest login if guest mode is enabled
+    if (!guestModeEnabled) {
+      return;
+    }
+    
+    setIsGuest(true);
+    setIsAdmin(false);
+    setAdminKey(null);
+    sessionStorage.setItem(GUEST_SESSION_STORAGE, 'true');
+    // Clear any admin session data
     sessionStorage.removeItem(ADMIN_KEY_STORAGE);
     sessionStorage.removeItem(ADMIN_SESSION_STORAGE);
   };
 
   const value: AdminContextType = {
     isAdmin,
+    isGuest,
     adminKey,
     login,
+    loginAsGuest,
     logout,
-    isLoading
+    isLoading,
+    adminKeyConfigured,
+    guestModeEnabled
   };
 
   return (

--- a/configure/src/hooks/useDashboardData.js
+++ b/configure/src/hooks/useDashboardData.js
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAdmin } from '@/contexts/AdminContext';
 
 const API_BASE = process.env.NODE_ENV === 'development' 
   ? 'http://localhost:7000' 
   : window.location.origin;
 
+
+// Hook for fetching main dashboard data
 export function useDashboardData() {
-  const { adminKey, isAdmin } = useAdmin();
+  const { adminKey, isAdmin, isGuest, logout } = useAdmin();
   const [data, setData] = useState({
     systemOverview: null,
     quickStats: null,
@@ -21,29 +23,43 @@ export function useDashboardData() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      // Only fetch if user is admin
-      if (!isAdmin) {
+      // Only fetch if user is admin or guest
+      if (!isAdmin && !isGuest) {
         setLoading(false);
         return;
       }
 
-      // Fetch all dashboard data
+      // Build headers - only include admin key for admin users
       const headers = {
         'Content-Type': 'application/json'
       };
       
-      if (adminKey) {
+      // Only add admin key header for admin users
+      if (isAdmin && adminKey) {
         headers['x-admin-key'] = adminKey;
       }
 
+      // Fetch public endpoint (overview) - accessible by both guest and admin
       const response = await fetch(`${API_BASE}/api/dashboard/overview`, {
         headers
       });
+
+      // Handle 401 responses - for admin users, trigger re-authentication
+      // For guest users, this shouldn't happen if guest mode is enabled
+      if (response.status === 401) {
+        if (isAdmin) {
+          logout();
+          setError('Session expired. Please log in again.');
+        } else {
+          setError('Access denied. Guest mode may be disabled.');
+        }
+        return;
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -57,10 +73,15 @@ export function useDashboardData() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isAdmin, isGuest, adminKey, logout]);
 
-  const clearCache = async (type) => {
+  const clearCache = useCallback(async (type) => {
     try {
+      // Only allow cache clear if user is admin (protected endpoint)
+      if (!isAdmin) {
+        throw new Error('Not authenticated - admin access required');
+      }
+
       const headers = {
         'Content-Type': 'application/json'
       };
@@ -74,6 +95,12 @@ export function useDashboardData() {
         headers,
         body: JSON.stringify({ type })
       });
+
+      // Handle 401 responses by triggering re-authentication
+      if (response.status === 401) {
+        logout();
+        throw new Error('Session expired. Please log in again.');
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -91,11 +118,11 @@ export function useDashboardData() {
       console.error('Error clearing cache:', err);
       throw err;
     }
-  };
+  }, [isAdmin, adminKey, logout, fetchData]);
 
   useEffect(() => {
     fetchData();
-  }, [isAdmin, adminKey]);
+  }, [fetchData]);
 
   return {
     data,
@@ -106,8 +133,11 @@ export function useDashboardData() {
   };
 }
 
+
+// Hook for fetching dashboard statistics
+
 export function useDashboardStats() {
-  const { adminKey, isAdmin } = useAdmin();
+  const { adminKey, isAdmin, isGuest, logout } = useAdmin();
   const [stats, setStats] = useState({
     quickStats: null,
     cachePerformance: null,
@@ -117,28 +147,41 @@ export function useDashboardStats() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      // Only fetch if user is admin
-      if (!isAdmin) {
+      // Allow fetching for both admin and guest users
+      if (!isAdmin && !isGuest) {
         setLoading(false);
         return;
       }
 
+      // Build headers - only include admin key for admin users
       const headers = {
         'Content-Type': 'application/json'
       };
       
-      if (adminKey) {
+      // Only add admin key header for admin users
+      if (isAdmin && adminKey) {
         headers['x-admin-key'] = adminKey;
       }
 
       const response = await fetch(`${API_BASE}/api/dashboard/stats`, {
         headers
       });
+
+      // Handle 401 responses
+      if (response.status === 401) {
+        if (isAdmin) {
+          logout();
+          setError('Session expired. Please log in again.');
+        } else {
+          setError('Access denied. Guest mode may be disabled.');
+        }
+        return;
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -152,16 +195,19 @@ export function useDashboardStats() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isAdmin, isGuest, adminKey, logout]);
 
   useEffect(() => {
     fetchStats();
     
     // Auto-refresh every 30 seconds to get updated provider performance data
+    // Only set up interval if user is admin or guest
+    if (!isAdmin && !isGuest) return;
+    
     const interval = setInterval(fetchStats, 30000);
     
     return () => clearInterval(interval);
-  }, [isAdmin, adminKey]);
+  }, [fetchStats, isAdmin, isGuest]);
 
   return {
     stats,
@@ -171,8 +217,10 @@ export function useDashboardStats() {
   };
 }
 
+
+// Hook for fetching system data
 export function useDashboardSystem() {
-  const { adminKey, isAdmin } = useAdmin();
+  const { adminKey, isAdmin, isGuest, logout } = useAdmin();
   const [systemData, setSystemData] = useState({
     systemConfig: null,
     resourceUsage: null
@@ -181,28 +229,41 @@ export function useDashboardSystem() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchSystemData = async () => {
+  const fetchSystemData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      // Only fetch if user is admin
-      if (!isAdmin) {
+      // Allow fetching for both admin and guest users
+      if (!isAdmin && !isGuest) {
         setLoading(false);
         return;
       }
 
+      // Build headers - only include admin key for admin users
       const headers = {
         'Content-Type': 'application/json'
       };
       
-      if (adminKey) {
+      // Only add admin key header for admin users
+      if (isAdmin && adminKey) {
         headers['x-admin-key'] = adminKey;
       }
 
       const response = await fetch(`${API_BASE}/api/dashboard/system`, {
         headers
       });
+
+      // Handle 401 responses
+      if (response.status === 401) {
+        if (isAdmin) {
+          logout();
+          setError('Session expired. Please log in again.');
+        } else {
+          setError('Access denied. Guest mode may be disabled.');
+        }
+        return;
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -216,16 +277,19 @@ export function useDashboardSystem() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isAdmin, isGuest, adminKey, logout]);
 
   useEffect(() => {
     fetchSystemData();
     
     // Auto-refresh every 60 seconds for system data
+    // Only set up interval if user is admin or guest
+    if (!isAdmin && !isGuest) return;
+    
     const interval = setInterval(fetchSystemData, 60000);
     
     return () => clearInterval(interval);
-  }, [isAdmin, adminKey]);
+  }, [fetchSystemData, isAdmin, isGuest]);
 
   return {
     systemData,
@@ -235,8 +299,10 @@ export function useDashboardSystem() {
   };
 }
 
+
+// Hook for fetching operations data (admin-only)
 export function useDashboardOperations() {
-  const { adminKey, isAdmin } = useAdmin();
+  const { adminKey, isAdmin, logout } = useAdmin();
   const [operationsData, setOperationsData] = useState({
     errorLogs: null,
     maintenanceTasks: null
@@ -245,13 +311,19 @@ export function useDashboardOperations() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchOperationsData = async () => {
+  const fetchOperationsData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      // Only fetch if user is admin
+      // Only fetch if user is admin - this is a protected endpoint
+      // Guest users should not have access to operations data
       if (!isAdmin) {
+        // Return empty data for non-admin users (including guests)
+        setOperationsData({
+          errorLogs: null,
+          maintenanceTasks: null
+        });
         setLoading(false);
         return;
       }
@@ -260,6 +332,7 @@ export function useDashboardOperations() {
         'Content-Type': 'application/json'
       };
       
+      // Always include admin key for this protected endpoint
       if (adminKey) {
         headers['x-admin-key'] = adminKey;
       }
@@ -267,6 +340,13 @@ export function useDashboardOperations() {
       const response = await fetch(`${API_BASE}/api/dashboard/operations`, {
         headers
       });
+
+      // Handle 401 responses by triggering re-authentication
+      if (response.status === 401) {
+        logout();
+        setError('Session expired. Please log in again.');
+        return;
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -280,11 +360,11 @@ export function useDashboardOperations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isAdmin, adminKey, logout]);
 
   useEffect(() => {
     fetchOperationsData();
-  }, [isAdmin, adminKey]);
+  }, [fetchOperationsData]);
 
   return {
     operationsData,


### PR DESCRIPTION
- Dashboard can now be fully hidden from unauthenticated users
- Added 'Guest Mode' login that allows access to insensitive data without auth
- Added DISABLE_GUEST_MODE environment variable to disable guest access 
- Note: Please set ADMIN_KEY if you haven't already, it's recommended. 
- Guest access is enabled by default, so please set DISABLE_GUEST_MODE=true if you want the dashboard to be fully locked down.