### PR TITLE
fix: AI search on without key when importing

### DIFF
--- a/configure/src/components/sections/SearchSettings.tsx
+++ b/configure/src/components/sections/SearchSettings.tsx
@@ -779,9 +779,9 @@ export function SearchSettings() {
                                 <div>
                                     <Switch
                                         id="ai-search-enabled"
-                                        checked={config.search.ai_enabled && !!config.apiKeys?.gemini?.trim()}
+                                        checked={config.search.ai_enabled}
                                         onCheckedChange={handleAiToggle}
-                                        disabled={!config.apiKeys?.gemini?.trim()}
+                                        disabled={!config.apiKeys?.gemini?.trim() && !config.search.ai_enabled}
                                         aria-label="Enable AI-powered search"
                                     />
                                 </div>


### PR DESCRIPTION
If you were to import a configuration from someone else and they had gemini search enabled but you don't want to use it, it would show that it is required on the configuration page even though under search it appeared to be off in settings (even though it was not). A workaround for this would be to enter in some random letters into the API key field for it, then turn off search, and then delete the random letters. This fix will allow you to disable the toggle without the key, but not enable it.