### PR TITLE
fix: RPDB/TOP adoption metrics stuck at 0% in admin dashboard

### DIFF
--- a/addon/lib/dashboardApi.js
+++ b/addon/lib/dashboardApi.js
@@ -879,8 +879,7 @@ class DashboardAPI {
       if (config.mdblistWatchTracking) stats.features.mdblistWatchTracking++;
       if (config.anilistWatchTracking) stats.features.anilistWatchTracking++;
       if (config.simklWatchTracking) stats.features.simklWatchTracking++;
-      if (config.posterRatingProvider === 'rpdb') stats.features.ratingPostersRpdb++;
-      if (config.posterRatingProvider === 'top') stats.features.ratingPostersTop++;
+      config.posterRatingProvider === 'top' ? stats.features.ratingPostersTop++ : stats.features.ratingPostersRpdb++;
       if (config.search?.ai_enabled) stats.features.aiSearchEnabled++;
     });
 


### PR DESCRIPTION
## Problem
In the admin dashboard's System tab, the Rating Posters adoption metrics (RPDB and TOP) were stuck at 0% even when users had configured rating posters.

## Root Cause
The aggregation logic used strict equality checks (`config.posterRatingProvider === 'rpdb'` and `=== 'top'`). Many user configs don't explicitly store `posterRatingProvider` when it's the default — it may be `undefined` in configs saved before the field existed or when the frontend omits default values.

## Solution
Use a ternary: when `posterRatingProvider === 'top'`, count TOP; otherwise count RPDB. This correctly treats `undefined`/missing as the default (RPDB), matching the runtime behavior in `parseProps.js` and `getCache.js` which use `config.posterRatingProvider || 'rpdb'`.

## Changes
- `addon/lib/dashboardApi.js`: Simplified the aggregation logic in `calculateConfigStats` to handle missing posterRatingProvider.