### PR TITLE
docs: reduce "quiet hours" ambiguity in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,7 @@ CATALOG_WARMUP_RESUME_ON_RESTART=true
 # Enable quiet hours for catalog warming (Default: false)
 CATALOG_WARMUP_QUIET_HOURS_ENABLED=false
 # Quiet hours time range (e.g., 02:00-06:00)
+# Catalog warming will never run during the configured quiet hours
 CATALOG_WARMUP_QUIET_HOURS=02:00-06:00
 # Delay between catalog warmup tasks (in ms)
 CATALOG_WARMUP_TASK_DELAY_MS=100
@@ -157,6 +158,7 @@ MAL_WARMUP_TASK_DELAY_MS=100
 # Enable quiet hours for MAL warming (Default: false)
 MAL_WARMUP_QUIET_HOURS_ENABLED=false
 # Quiet hours range for MAL warming (e.g., 2-8)
+# MAL-specific catalog warming will never run during the configured quiet hours
 MAL_WARMUP_QUIET_HOURS_RANGE=2-8
 # Number of priority pages for MAL warming
 MAL_WARMUP_PRIORITY_PAGES=2
@@ -180,6 +182,7 @@ CACHE_CLEANUP_AUTO_ENABLED=true
 # Enable quiet hours for cache cleanup (Default: false)
 CACHE_CLEANUP_QUIET_HOURS_ENABLED=false
 # Quiet hours for cache cleanup (e.g., 02:00-06:00)
+# Cache cleanup will never run during the configured quiet hours
 CACHE_CLEANUP_QUIET_HOURS=02:00-06:00
 
 


### PR DESCRIPTION
Added comments to clarify the purpose of quiet hours for catalog warming, MAL warming, and cache cleanup.

This is necessary as "quiet hours" wording is ambiguous and has no standard meaning.