### PR TITLE
fix: prevent OOM crash from unbounded in-memory caches

### DIFF
--- a/addon/lib/getCache.js
+++ b/addon/lib/getCache.js
@@ -74,8 +74,8 @@ const SELF_HEALING_CONFIG = {
   corruptedEntryThreshold: parseInt(process.env.CACHE_CORRUPTED_THRESHOLD || '10', 10)
 };
 
-const MAX_TRACKED_KEYS = parseInt(process.env.MAX_TRACKED_KEYS || '20000', 10);
-const KEYS_TO_KEEP_AFTER_PRUNE = parseInt(process.env.KEYS_TO_KEEP_AFTER_PRUNE || '5000', 10);
+const MAX_TRACKED_KEYS = parseInt(process.env.MAX_TRACKED_KEYS || '5000', 10);
+const KEYS_TO_KEEP_AFTER_PRUNE = parseInt(process.env.KEYS_TO_KEEP_AFTER_PRUNE || '1000', 10);
 
 const inFlightRequests = new Map();
 const cacheValidator = require('./cacheValidator');
@@ -256,6 +256,17 @@ function safeParseConfigString(configString) {
  */
 function updateCacheHealth(key, type, success = true) {
   cacheHealth.keyAccessCounts.set(key, (cacheHealth.keyAccessCounts.get(key) || 0) + 1);
+
+  // Prune immediately if map grows too large (don't wait for health check interval)
+  if (cacheHealth.keyAccessCounts.size > MAX_TRACKED_KEYS) {
+    const sorted = Array.from(cacheHealth.keyAccessCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, KEYS_TO_KEEP_AFTER_PRUNE);
+    cacheHealth.keyAccessCounts.clear();
+    for (const [k, count] of sorted) {
+      cacheHealth.keyAccessCounts.set(k, count);
+    }
+  }
   
   if (success) {
     if (type === 'hit') {

--- a/addon/lib/id-mapper.js
+++ b/addon/lib/id-mapper.js
@@ -23,13 +23,44 @@ const UPDATE_INTERVAL_HOURS = parseInt(process.env.ANIME_LIST_UPDATE_INTERVAL_HO
 const UPDATE_INTERVAL_KITSU_TO_IMDB_HOURS = parseInt(process.env.KITSU_TO_IMDB_UPDATE_INTERVAL_HOURS) || 24; // Update every 24 hours (configurable)
 const UPDATE_INTERVAL_TRAKT_ANIME_MOVIES_HOURS = parseInt(process.env.TRAKT_ANIME_MOVIES_UPDATE_INTERVAL_HOURS) || 24; // Update every 24 hours (configurable)
 
+// Simple size-limited Map that evicts oldest entries when full
+class SizeLimitedMap {
+  constructor(maxSize) {
+    this._map = new Map();
+    this._maxSize = maxSize;
+  }
+  has(key) { return this._map.has(key); }
+  get(key) { return this._map.get(key); }
+  set(key, value) {
+    // Delete first so re-insertion moves key to end (most recent)
+    if (this._map.has(key)) this._map.delete(key);
+    this._map.set(key, value);
+    // Evict oldest entries if over limit
+    if (this._map.size > this._maxSize) {
+      const it = this._map.keys();
+      this._map.delete(it.next().value);
+    }
+    return this;
+  }
+  delete(key) { return this._map.delete(key); }
+  clear() { this._map.clear(); }
+  get size() { return this._map.size; }
+  keys() { return this._map.keys(); }
+  values() { return this._map.values(); }
+  entries() { return this._map.entries(); }
+  forEach(fn) { this._map.forEach(fn); }
+  [Symbol.iterator]() { return this._map[Symbol.iterator](); }
+}
+
+const ID_MAPPER_CACHE_MAX_SIZE = parseInt(process.env.ID_MAPPER_CACHE_MAX_SIZE || '2000', 10);
+
 let animeIdMap = new Map();
 let tvdbIdToAnimeListMap = new Map();
 let isInitialized = false;
 let tvdbIdMap = new Map();
-const franchiseMapCache = new Map();
-const tmdbFranchiseInfoCache = new Map();
-const tmdbSeasonCache = new Map();
+const franchiseMapCache = new SizeLimitedMap(ID_MAPPER_CACHE_MAX_SIZE);
+const tmdbFranchiseInfoCache = new SizeLimitedMap(ID_MAPPER_CACHE_MAX_SIZE);
+const tmdbSeasonCache = new SizeLimitedMap(ID_MAPPER_CACHE_MAX_SIZE);
 
 // Auxiliary index maps for O(1) lookups (instead of O(N) Array.from().find())
 let kitsuIdMap = new Map();
@@ -58,7 +89,7 @@ async function getTmdbSeasonInfo(tmdbId, config = {}) {
 }
 
 let tmdbIndexArray; 
-const kitsuToImdbCache = new Map();
+const kitsuToImdbCache = new SizeLimitedMap(ID_MAPPER_CACHE_MAX_SIZE);
 let imdbIdToAnimeListMap = new Map();
 let updateInterval = null;
 let kitsuToImdbMapping = null;


### PR DESCRIPTION
## Summary

Production instances are crashing with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` at ~4GB.

Root cause: several in-memory Maps in `id-mapper.js` (`tmdbSeasonCache`, `franchiseMapCache`, `tmdbFranchiseInfoCache`, `kitsuToImdbCache`) grow without bound as catalog warming processes thousands of shows. Additionally, `keyAccessCounts` in `getCache.js` could accumulate up to 20,000 entries between 5-minute pruning cycles.

### Changes

- **Add `SizeLimitedMap` with LRU eviction** for the 4 unbounded caches in `id-mapper.js` — caps at 2000 entries each (configurable via `ID_MAPPER_CACHE_MAX_SIZE` env var), evicting oldest entries when full
- **Reduce `keyAccessCounts` defaults** from 20,000→5,000 max tracked keys and 5,000→1,000 keys retained after prune
- **Add inline pruning** of `keyAccessCounts` so it prunes immediately when exceeding the limit, rather than waiting for the 5-minute health check interval

### Configuration

New env vars (all optional with sensible defaults):
- `ID_MAPPER_CACHE_MAX_SIZE` — max entries per id-mapper cache (default: `2000`)
- `MAX_TRACKED_KEYS` — now defaults to `5000` (was `20000`)
- `KEYS_TO_KEEP_AFTER_PRUNE` — now defaults to `1000` (was `5000`)

## Test plan

- [ ] Deploy to a staging instance and monitor heap usage over time during catalog warming
- [ ] Verify id-mapper lookups still return correct results (cache hits work, evicted entries are re-fetched)
- [ ] Confirm cache health logging still reports top keys correctly
- [ ] Monitor for the OOM crash — should no longer occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)