### PR TITLE
Fix RPDB Posters When Using TVDB ID

### DIFF
--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -1207,7 +1207,7 @@ function getRpdbPoster(type, ids, language, rpdbkey) {
     if (type === 'movie') {
         if (tvdbId) {
             idType = 'tvdb';
-            fullMediaId = tvdbId;
+            fullMediaId = `movie-${tvdbId}`;
         } else if (tmdbId) {
             idType = 'tmdb';
             fullMediaId = `movie-${tmdbId}`;
@@ -1218,7 +1218,7 @@ function getRpdbPoster(type, ids, language, rpdbkey) {
     } else if (type === 'series') {
         if (tvdbId) {
             idType = 'tvdb';
-            fullMediaId = tvdbId;
+            fullMediaId = `series-${tvdbId}`;
         } else if (tmdbId) {
             idType = 'tmdb';
             fullMediaId = `series-${tmdbId}`;


### PR DESCRIPTION
Using TVDB also requires the movie / series type in the ID for best results with RPDB.

Examples without type that fail:
- https://api.ratingposterdb.com/t0-free-rpdb/tvdb/poster-default/465690.jpg
- https://api.ratingposterdb.com/t0-free-rpdb/tvdb/poster-default/464815.jpg

Same examples with type added:
- https://api.ratingposterdb.com/t0-free-rpdb/tvdb/poster-default/series-465690.jpg
- https://api.ratingposterdb.com/t0-free-rpdb/tvdb/poster-default/series-464815.jpg