### PR TITLE
Add raw {id} placeholder support for custom art URLs

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -117,6 +117,7 @@ function extractIdsFromMeta(meta) {
   if (!meta) return ids;
 
   const id = meta.id || '';
+  if (id) ids.id = id;
   if (id.startsWith('tmdb:')) ids.tmdbId = id.slice(5);
   else if (id.startsWith('tvdb:')) ids.tvdbId = id.slice(5);
   else if (id.startsWith('kitsu:')) ids.kitsuId = id.slice(6);

--- a/addon/tests/custom-art-id-placeholder.test.js
+++ b/addon/tests/custom-art-id-placeholder.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function extractFunction(source, functionName) {
+  const startToken = `function ${functionName}`;
+  const startIndex = source.indexOf(startToken);
+  assert.notEqual(startIndex, -1, `Expected ${functionName} to exist`);
+
+  const bodyStart = source.indexOf('{', startIndex);
+  assert.notEqual(bodyStart, -1, `Expected ${functionName} body`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    if (depth === 0) {
+      return source.slice(startIndex, index + 1);
+    }
+  }
+
+  throw new Error(`Could not extract ${functionName}`);
+}
+
+const parsePropsSource = fs.readFileSync(
+  path.join(__dirname, '..', 'utils', 'parseProps.js'),
+  'utf8',
+);
+const indexSource = fs.readFileSync(
+  path.join(__dirname, '..', 'index.js'),
+  'utf8',
+);
+
+const resolvePattern = vm.runInNewContext(
+  `(${extractFunction(parsePropsSource, 'resolvePattern')})`,
+);
+const extractIdsFromMeta = vm.runInNewContext(
+  `(${extractFunction(indexSource, 'extractIdsFromMeta')})`,
+);
+
+test('extractIdsFromMeta preserves the raw meta id', () => {
+  const ids = extractIdsFromMeta({ id: 'mal:16498' });
+
+  assert.equal(ids.id, 'mal:16498');
+  assert.equal(ids.malId, '16498');
+});
+
+test('resolvePattern supports the raw id placeholder', () => {
+  const url = resolvePattern(
+    'https://example.com/poster/{id}.jpg?lang={language_short}',
+    { id: 'mal:16498', malId: '16498' },
+    'series',
+    { language: 'en-US', apiKeys: {} },
+  );
+
+  assert.equal(url, 'https://example.com/poster/mal:16498.jpg?lang=en');
+});

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -66,7 +66,7 @@ function isPosterRatingEnabled(config) {
  *                       imdb: 'tt1234567', tmdb/tvdb: 'movie-12345' or 'series-12345'
  *
  * @param {string} pattern - URL pattern with placeholders
- * @param {object} ids - Object with tmdbId, imdbId, tvdbId, malId, kitsuId, anilistId, anidbId properties
+ * @param {object} ids - Object with id, tmdbId, imdbId, tvdbId, malId, kitsuId, anilistId, anidbId properties
  * @param {string} type - Content type (movie, series)
  * @param {object} [config] - User config (for API key and language placeholders)
  * @returns {string|null} Resolved URL or null
@@ -91,6 +91,7 @@ function resolvePattern(pattern, ids, type, config, extra) {
 
   const lang = config?.language || 'en-US';
   const placeholders = {
+    '{id}': ids?.id || '',
     '{tmdb_id}': ids?.tmdbId || '',
     '{imdb_id}': ids?.imdbId || '',
     '{tvdb_id}': ids?.tvdbId || '',

--- a/configure/src/components/sections/ArtProviderSettings.tsx
+++ b/configure/src/components/sections/ArtProviderSettings.tsx
@@ -517,7 +517,7 @@ export function ArtProviderSettings() {
                   : 'Override art with custom URL patterns. If a placeholder references an unavailable value, normal art is used instead.'}
               </p>
               <p className="text-sm text-muted-foreground mt-1">
-                ID placeholders: <code>{'{imdb_id}'}</code>, <code>{'{tmdb_id}'}</code>, <code>{'{tvdb_id}'}</code>, <code>{'{mal_id}'}</code>, <code>{'{kitsu_id}'}</code>, <code>{'{anilist_id}'}</code>, <code>{'{anidb_id}'}</code>, <code>{'{type}'}</code>.
+                ID placeholders: <code>{'{id}'}</code>, <code>{'{imdb_id}'}</code>, <code>{'{tmdb_id}'}</code>, <code>{'{tvdb_id}'}</code>, <code>{'{mal_id}'}</code>, <code>{'{kitsu_id}'}</code>, <code>{'{anilist_id}'}</code>, <code>{'{anidb_id}'}</code>, <code>{'{type}'}</code>.
                 API keys: <code>{'{rpdb_key}'}</code>, <code>{'{top_key}'}</code>, <code>{'{tmdb_key}'}</code>, <code>{'{mdblist_key}'}</code>, <code>{'{fanart_key}'}</code>.
                 Language: <code>{'{language}'}</code> (e.g. fr-FR), <code>{'{language_short}'}</code> (e.g. fr).
                 RPDB/TOP patterns automatically fall back to alternative IDs when the primary one is unavailable.


### PR DESCRIPTION
## Summary

- add `{id}` placeholder support for custom art URL patterns
- preserve the raw `meta.id` during custom art ID extraction
- document `{id}` in the configurator helper text
- add a focused regression test for raw id extraction and pattern substitution

## Why

XRDB and similar integrations sometimes need the original source id, such as `mal:16498`, when building custom poster URLs. AIOMetadata already exposes provider specific placeholders like `{mal_id}` and `{tmdb_id}`, but without a raw `{id}` placeholder mixed content integrations have to choose between provider specific fallbacks that do not cover every item cleanly.

This change is additive only and keeps all existing placeholders unchanged.

## Root Cause

Custom art URL resolution only replaced provider specific placeholders and did not preserve the raw `meta.id` as a resolvable value. That blocked integrations that need the original source id for cases like MAL anime search and catalog items.

## Validation

- `node --test addon/tests/custom-art-id-placeholder.test.js`
- `npx eslint addon/index.js addon/utils/parseProps.js configure/src/components/sections/ArtProviderSettings.tsx addon/tests/custom-art-id-placeholder.test.js`
