### PR TITLE
feat: update Top Posters API domain and add user-agent support

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3962,6 +3962,7 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
     }
 
     {
+      const userAgent = req.headers['user-agent'] || '';
       const host = process.env.HOST_NAME.startsWith('http') ? process.env.HOST_NAME : `https://${process.env.HOST_NAME}`;
       const { resolveCustomArtUrl, getDefaultPosterPattern, getDefaultThumbnailPattern, getPosterRatingApiKey } = require('./utils/parseProps');
       const ids = extractIdsFromMeta(result.meta);
@@ -3977,17 +3978,17 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
               result.meta.poster = `${host}/poster/${metaType}/${proxyId}?fallback=${encodeURIComponent(result.meta.poster || '')}&lang=${config.language || 'en-US'}&key=${proxyApiKey}`;
             }
           } else {
-            const resolved = resolveCustomArtUrl(metaPosterPattern, ids, metaType, config);
+            const resolved = resolveCustomArtUrl(metaPosterPattern, ids, metaType, config, { userAgent });
             if (resolved) result.meta.poster = resolved;
           }
         }
       }
       if (config.customBackgroundUrlPattern) {
-        const resolved = resolveCustomArtUrl(config.customBackgroundUrlPattern, ids, metaType, config);
+        const resolved = resolveCustomArtUrl(config.customBackgroundUrlPattern, ids, metaType, config, { userAgent });
         if (resolved) result.meta.background = resolved;
       }
       if (config.customLogoUrlPattern) {
-        const resolved = resolveCustomArtUrl(config.customLogoUrlPattern, ids, metaType, config);
+        const resolved = resolveCustomArtUrl(config.customLogoUrlPattern, ids, metaType, config, { userAgent });
         if (resolved) result.meta.logo = resolved;
       }
       // Apply thumbnail pattern to episode videos
@@ -4009,6 +4010,7 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
                 episode,
                 blur: config.blurThumbs ? 'true' : 'false',
                 thumbnail: encodeURIComponent(originalThumb),
+                userAgent,
               });
               if (resolved) {
                 video.thumbnail = resolved;

--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -1310,7 +1310,7 @@ class ConfigApi {
       },
 
       topPoster: async (key) => {
-        const url = `https://api.top-streaming.stream/auth/verify/${key}`;
+        const url = `https://api.top-posters.com/auth/verify/${key}`;
         const response = await serviceRequest(url, { method: "GET" });
         return (
           response &&

--- a/addon/lib/getCache.js
+++ b/addon/lib/getCache.js
@@ -1316,7 +1316,7 @@ const configHash = hashConfig(metaConfigString);
         if (rawPoster.includes('/poster/') && urlObj.searchParams.has('fallback')) {
            rawPoster = decodeURIComponent(urlObj.searchParams.get('fallback'));
         }
-        else if (urlObj.hostname.includes('top-streaming.stream') && urlObj.searchParams.has('fallback_url')) {
+        else if (urlObj.hostname.includes('top-posters.com') && urlObj.searchParams.has('fallback_url')) {
            rawPoster = decodeURIComponent(urlObj.searchParams.get('fallback_url'));
         }
 

--- a/addon/utils/imageProcessor.js
+++ b/addon/utils/imageProcessor.js
@@ -19,7 +19,7 @@ const ALLOWED_DOMAINS = [
   'kitsu.io',
   'anilist.co',
   'anidb.net',
-  'top-streaming.stream'
+  'top-posters.com'
 ];
 
 // Allowed file extensions

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -75,7 +75,7 @@ function resolveCustomArtUrl(pattern, ids, type, config, extra) {
   if (!pattern || typeof pattern !== 'string' || !pattern.trim()) return null;
 
   // For RPDB/TOP patterns, try ID fallback: imdb → tmdb → tvdb
-  const isRatingPosterService = pattern.includes('ratingposterdb.com') || pattern.includes('top-streaming.stream');
+  const isRatingPosterService = pattern.includes('ratingposterdb.com') || pattern.includes('top-posters.com');
   if (isRatingPosterService) {
     return resolveRatingPosterUrl(pattern, ids, type, config, extra);
   }
@@ -108,6 +108,7 @@ function resolvePattern(pattern, ids, type, config, extra) {
     '{top_key}': config?.apiKeys?.topPoster || '',
     '{mdblist_key}': config?.apiKeys?.mdblist || '',
     '{fanart_key}': config?.apiKeys?.fanart || '',
+    '{user_agent}': extra?.userAgent || '',
   };
 
   // Optional placeholders — resolve to empty string without failing
@@ -184,9 +185,9 @@ function resolveRatingPosterUrl(pattern, ids, type, config, extra) {
 /** Default poster URL pattern for RPDB */
 const RPDB_DEFAULT_PATTERN = 'https://api.ratingposterdb.com/{rpdb_key}/imdb/poster-default/{imdb_id}.jpg?fallback=true';
 /** Default poster URL pattern for TOP Posters */
-const TOP_DEFAULT_PATTERN = 'https://api.top-streaming.stream/{top_key}/imdb/poster-default/{imdb_id}.jpg?lang={language_short}';
+const TOP_DEFAULT_PATTERN = 'https://api.top-posters.com/{top_key}/imdb/poster/{imdb_id}.jpg?lang={language_short}';
 /** Default episode thumbnail URL pattern for TOP Posters */
-const TOP_DEFAULT_THUMBNAIL_PATTERN = 'https://api.top-streaming.stream/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?resolution=w500&blur={blur}&fallback_url={thumbnail}';
+const TOP_DEFAULT_THUMBNAIL_PATTERN = 'https://api.top-posters.com/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?blur={blur}&fallback_url={thumbnail}&user_agent={user_agent}';
 
 /**
  * Returns the default poster URL pattern for a given rating poster provider.
@@ -1397,7 +1398,7 @@ function getRpdbPoster(type, ids, language, rpdbkey) {
 
 function getTopPosterPoster(type, ids, language, topPosterKey, fallbackUrl = null) {
     const { tmdbId, imdbId } = ids;
-    let baseUrl = `https://api.top-streaming.stream`;
+    let baseUrl = `https://api.top-posters.com`;
     let idType = null;
     let fullMediaId = null;
     
@@ -1424,8 +1425,8 @@ function getTopPosterPoster(type, ids, language, topPosterKey, fallbackUrl = nul
         return null;
     }
 
-    // Top Poster API format: /{api_key}/{id_type}/poster-default/{media_id}.jpg
-    const urlPath = `${baseUrl}/${topPosterKey}/${idType}/poster-default/${fullMediaId}.jpg`;
+    // Top Poster API format: /{api_key}/{id_type}/poster/{media_id}.jpg
+    const urlPath = `${baseUrl}/${topPosterKey}/${idType}/poster/${fullMediaId}.jpg`;
     
     // Build query parameters
     // Top Poster API expects ISO 639-1 format (2-letter language code, e.g., 'en', 'it', 'pt')
@@ -1459,8 +1460,8 @@ function getTopPosterThumbnail(config, ids, season, episode, topPosterKey, resol
         return fallbackUrl;
     }
     const { tmdbId, imdbId } = ids;
-    const { blur = false } = options;
-    let baseUrl = `https://api.top-streaming.stream`;
+    const { blur = false, userAgent = '' } = options;
+    let baseUrl = `https://api.top-posters.com`;
     let idType = null;
     let fullMediaId = null;
     
@@ -1482,16 +1483,16 @@ function getTopPosterThumbnail(config, ids, season, episode, topPosterKey, resol
     
     // Build query parameters
     const params = new URLSearchParams();
-    if (resolution && resolution !== 'original') {
-        params.append('resolution', resolution);
-    }
     if (fallbackUrl) {
         params.append('fallback_url', fallbackUrl);
     }
     if (blur) {
         params.append('blur', 'true');
     }
-    
+    if (userAgent) {
+      params.append('user_agent', userAgent);
+    }
+
     return params.toString() ? `${urlPath}?${params.toString()}` : urlPath;
 }
 

--- a/configure/src/components/sections/ArtProviderSettings.tsx
+++ b/configure/src/components/sections/ArtProviderSettings.tsx
@@ -467,8 +467,8 @@ export function ArtProviderSettings() {
                 if (provider === 'rpdb') {
                   posterPattern = 'https://api.ratingposterdb.com/{rpdb_key}/imdb/poster-default/{imdb_id}.jpg?fallback=true';
                 } else if (provider === 'top') {
-                  posterPattern = 'https://api.top-streaming.stream/{top_key}/imdb/poster-default/{imdb_id}.jpg?lang={language_short}';
-                  thumbnailPattern = 'https://api.top-streaming.stream/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?resolution=w500&blur={blur}&fallback_url={thumbnail}';
+                  posterPattern = 'https://api.top-posters.com/{top_key}/imdb/poster/{imdb_id}.jpg?lang={language_short}';
+                  thumbnailPattern = 'https://api.top-posters.com/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?blur={blur}&fallback_url={thumbnail}&user_agent={user_agent}';
                 }
                 
                 setConfig(prev => ({ 
@@ -518,7 +518,7 @@ export function ArtProviderSettings() {
               </p>
               <p className="text-sm text-muted-foreground mt-1">
                 ID placeholders: <code>{'{imdb_id}'}</code>, <code>{'{tmdb_id}'}</code>, <code>{'{tvdb_id}'}</code>, <code>{'{mal_id}'}</code>, <code>{'{kitsu_id}'}</code>, <code>{'{anilist_id}'}</code>, <code>{'{anidb_id}'}</code>, <code>{'{type}'}</code>.
-                API keys: <code>{'{rpdb_key}'}</code>, <code>{'{top_key}'}</code>, <code>{'{tmdb_key}'}</code>, <code>{'{mdblist_key}'}</code>, <code>{'{fanart_key}'}</code>.
+                API keys/Extra: <code>{'{rpdb_key}'}</code>, <code>{'{top_key}'}</code>, <code>{'{tmdb_key}'}</code>, <code>{'{mdblist_key}'}</code>, <code>{'{fanart_key}'}</code>, <code>{'{user_agent}'}</code>.
                 Language: <code>{'{language}'}</code> (e.g. fr-FR), <code>{'{language_short}'}</code> (e.g. fr).
                 RPDB/TOP patterns automatically fall back to alternative IDs when the primary one is unavailable.
               </p>
@@ -534,7 +534,7 @@ export function ArtProviderSettings() {
                     onClick={() => {
                       const pattern = config.posterRatingProvider === 'rpdb'
                         ? 'https://api.ratingposterdb.com/{rpdb_key}/imdb/poster-default/{imdb_id}.jpg?fallback=true'
-                        : 'https://api.top-streaming.stream/{top_key}/imdb/poster-default/{imdb_id}.jpg?lang={language_short}';
+                        : 'https://api.top-posters.com/{top_key}/imdb/poster/{imdb_id}.jpg?lang={language_short}';
                       setConfig(prev => ({ ...prev, customPosterUrlPattern: pattern }));
                     }}
                   >
@@ -574,7 +574,7 @@ export function ArtProviderSettings() {
                     size="sm"
                     className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
                     onClick={() => {
-                      const pattern = 'https://api.top-streaming.stream/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?resolution=w500&blur={blur}&fallback_url={thumbnail}';
+                      const pattern = 'https://api.top-posters.com/{top_key}/imdb/thumbnail/{imdb_id}/S{season}E{episode}.jpg?blur={blur}&fallback_url={thumbnail}&user_agent={user_agent}';
                       setConfig(prev => ({ ...prev, customThumbnailUrlPattern: pattern }));
                     }}
                   >
@@ -589,7 +589,7 @@ export function ArtProviderSettings() {
                 onChange={(e) => setConfig(prev => ({ ...prev, customThumbnailUrlPattern: e.target.value }))}
               />
               <p className="text-xs text-muted-foreground mt-1">
-                Extra placeholders: <code>{'{season}'}</code>, <code>{'{episode}'}</code>, <code>{'{blur}'}</code> (true/false from blur thumbs setting), <code>{'{thumbnail}'}</code> (original thumbnail URL, encoded).
+                Extra placeholders: <code>{'{season}'}</code>, <code>{'{episode}'}</code>, <code>{'{blur}'}</code> (true/false from blur thumbs setting), <code>{'{thumbnail}'}</code> (original thumbnail URL, encoded), <code>{'{user_agent}'}</code>.
               </p>
             </div>
           </div>

--- a/configure/src/components/sections/IntegrationsSettings.tsx
+++ b/configure/src/components/sections/IntegrationsSettings.tsx
@@ -551,7 +551,7 @@ export function IntegrationsSettings() {
         <ApiKeyInput
           id="topPoster"
           label="TOP Posters API Key"
-          linkHref="https://api.top-streaming.stream/user/dashboard"
+          linkHref="https://api.top-posters.com/user/dashboard"
           validationStatus={validationStatus.topPoster || 'idle'}
           onKeyChange={handleKeyChange}
         />


### PR DESCRIPTION
## Description
This PR updates the integration with the Top Posters API to reflect their new domain and adds dynamic `user-agent` support for episode thumbnail requests.

## Changes:
- Updated Top Posters API base URL to `https://api.top-posters.com`.
- Changed the default identifier path from `poster-default` to `poster`.
- Removed resolution parameter from thumbnail URL (not necessary).
- Added the `{user_agent}` placeholder in URL resolution.
- Extracted `user-agent` header from incoming Stremio API requests and passed it down to the thumbnail generation logic.
- Updated the Frontend UI default configuration and documentation to include the new `{user_agent}` placeholder.