### PR TITLE
fix(configure): restore theme toggle and add system color scheme detection

### DIFF
--- a/configure/src/App.tsx
+++ b/configure/src/App.tsx
@@ -11,7 +11,7 @@ function AppContent() {
   const { config } = useConfig();
   
   return (
-    <div className="dark min-h-screen w-full bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
+    <div className="min-h-screen w-full bg-background text-foreground flex flex-col items-center p-4 sm:p-6">
       <Header />
       
       {/* Custom Description Blurb - Outside main card */}

--- a/configure/src/components/ThemeProvider.tsx
+++ b/configure/src/components/ThemeProvider.tsx
@@ -22,7 +22,7 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
 export function ThemeProvider({
   children,
-  defaultTheme = "dark", // Your requested default
+  defaultTheme = "system",
   storageKey = "vite-ui-theme",
   ...props
 }: ThemeProviderProps) {
@@ -31,17 +31,19 @@ export function ThemeProvider({
   );
 
   useEffect(() => {
-    const root = window.document.documentElement; // This is the <html> tag
+    const root = window.document.documentElement;
 
     root.classList.remove("light", "dark");
 
     if (theme === "system") {
       const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
       root.classList.add(systemTheme);
+      root.style.colorScheme = systemTheme;
       return;
     }
 
     root.classList.add(theme);
+    root.style.colorScheme = theme;
   }, [theme]);
 
   const value = {

--- a/configure/src/components/sections/ProvidersSettings.tsx
+++ b/configure/src/components/sections/ProvidersSettings.tsx
@@ -117,7 +117,7 @@ export function ProvidersSettings() {
       <div>
         <h2 className="text-2xl font-semibold">Metadata Providers</h2>
         <p className="text-muted-foreground mt-1">Choose your preferred source for metadata. Different providers may have better data for certain content.</p>
-        <p className="text-xs text-amber-400 mt-4 p-3 bg-amber-900/20 border border-amber-400/30 rounded-lg">
+        <p className="text-xs text-amber-700 dark:text-amber-400 mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-400/30 rounded-lg">
           <strong>Smart Fallback:</strong> If metadata for a title can't be found with your preferred provider (e.g., no TVDB entry for a TMDB movie), the addon will automatically use the item's original source to guarantee you get a result.
         </p>
       </div>

--- a/configure/src/main.tsx
+++ b/configure/src/main.tsx
@@ -12,7 +12,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider defaultTheme="dark" storageKey="aio-addon-theme">
+        <ThemeProvider defaultTheme="system" storageKey="aio-addon-theme">
           <ConfigProvider>
             <App />
           </ConfigProvider>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
         <link rel="apple-touch-icon" href="/favicon.png" />
         <link rel="shortcut icon" href="/favicon.png" type="image/png" />
         <meta name="theme-color" content="#01b4e4" />
+        <meta name="color-scheme" content="dark light" />
         <meta
             name="description"
             content="Configure your AIOMetadata Addon for Stremio"


### PR DESCRIPTION
Removes hardcoded `dark` class from the root div in `App.tsx`, this was locking the UI permanently in dark mode, causing the theme toggle to have no visible effect on the background or the Sun/Moon icons.

Fixes `defaultTheme` in both `ThemeProvider` and `main.tsx` from `"dark"` to `"system"` so first time visitors get the theme that matches their OS preference instead of always dark.

Applies the `color-scheme` CSS property dynamically so native browser elements (scrollbars, inputs, selects) render correctly in both themes.

Adds `<meta name="color-scheme" content="dark light">` to `index.html` so the page is marked as natively theme aware.

Fixes Smart Fallback alert contrast in light mode.