### PR TITLE
feat: support unified mixed MDBList catalogs by username/slug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,10 @@ dist
 *.save
 *.save.*
 temp/
+
+# Local addon runtime data
+addon/data/.migration-completed
+addon/data/*.cache
+addon/data/db.sqlite
+addon/data/db.sqlite-shm
+addon/data/db.sqlite-wal

--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -1,7 +1,7 @@
 require("dotenv").config();
 import { getGenreList } from "./getGenreList.js";
 import { getLanguages } from "./getLanguages.js";
-import { fetchMDBListItems, parseMDBListItems, fetchMDBListBatchMediaInfo, fetchMDBListUpNext, parseMDBListUpNextItems } from "../utils/mdbList.js";
+import { fetchMDBListItems, fetchMDBListItemsBySlug, parseMDBListItems, fetchMDBListBatchMediaInfo, fetchMDBListUpNext, parseMDBListUpNextItems, resolveMDBListUnifiedCatalogIdentity } from "../utils/mdbList.js";
 import { fetchStremThruCatalog, parseStremThruItems } from "../utils/stremthru.js";
 import { fetchTraktWatchlistItems, fetchTraktFavoritesItems, fetchTraktRecommendationsItems, fetchTraktListItems, fetchTraktListItemsById, parseTraktItems, fetchTraktMostFavoritedItems, fetchTraktCalendarShows, fetchTraktSearchItems, getTraktAccessToken } from "../utils/traktUtils.js";
 import { fetchSimklTrendingItems, fetchSimklWatchlistItems, parseSimklItems, getSimklToken, fetchSimklCalendarItems, fetchSimklGenreItems, fetchSimklDvdReleases } from "../utils/simklUtils.js";
@@ -60,22 +60,23 @@ function applyAgeRatingFilter(metas: any[], type: string, config: any): any[] {
     'NC-17': 'TV-MA'
   };
   
-  const isTvRating = type === 'series';
-  const finalUserRating = isTvRating ? (movieToTvMap[config.ageRating] || config.ageRating) : config.ageRating;
-  const ratingHierarchy = isTvRating ? tvRatingHierarchy : movieRatingHierarchy;
-  const userRatingIndex = ratingHierarchy.indexOf(finalUserRating);
-
-  if (userRatingIndex === -1) {
-    return metas;
-  }
-
   const filteredMetas = metas.filter(meta => {
+    const effectiveType = type === 'all' ? meta.type : type;
+    const isTvRating = effectiveType === 'series';
+    const finalUserRating = isTvRating ? (movieToTvMap[config.ageRating] || config.ageRating) : config.ageRating;
+    const ratingHierarchy = isTvRating ? tvRatingHierarchy : movieRatingHierarchy;
+    const userRatingIndex = ratingHierarchy.indexOf(finalUserRating);
+
+    if (userRatingIndex === -1) {
+      return true;
+    }
+
     let cert: string | null = null;
     
     if (meta.app_extras?.certification) {
       cert = meta.app_extras.certification;
     } else {
-      logger.debug(`[StremThru] ${type} ${meta.name}: No certification data available`);
+      logger.debug(`[StremThru] ${effectiveType} ${meta.name}: No certification data available`);
     }
 
     // If rating is PG-13 or lower, exclude NR content as it could be inappropriate
@@ -745,6 +746,41 @@ async function getTmdbAndMdbListCatalog(type: string, id: string, genre: string,
     const genreSlug = convertGenreToSlug(genre);
     if (genreSlug !== genre) {
       logger.debug(`Converted genre "${genre}" to slug "${genreSlug}"`);
+    }
+
+    const unifiedSlugIdentity = resolveMDBListUnifiedCatalogIdentity(catalogConfig, id);
+    if (unifiedSlugIdentity) {
+      logger.info(`Fetching MDBList unified catalog by slug: ${unifiedSlugIdentity.username}/${unifiedSlugIdentity.listSlug}, Genre: ${genre}, Page: ${page}`);
+
+      const response = await fetchMDBListItemsBySlug(
+        unifiedSlugIdentity.username,
+        unifiedSlugIdentity.listSlug,
+        config.apiKeys?.mdblist || process.env.MDBLIST_API_KEY || '',
+        language,
+        page,
+        sort,
+        order,
+        genreSlug,
+        catalogConfig?.cacheTTL
+      );
+
+      if (response.totalItems !== undefined && response.totalPages !== undefined) {
+        const pageInfo = `page ${page}/${response.totalPages}`;
+        const itemInfo = `${response.items.length} items`;
+        const totalInfo = `${response.totalItems} total`;
+        const statusInfo = response.hasMore ? 'more available' : 'end reached';
+
+        logger.debug(`MDBList unified-by-slug pagination - ${pageInfo}, ${itemInfo}, ${totalInfo}, ${statusInfo}`);
+
+        if (!response.hasMore && response.items.length === 0) {
+          logger.debug(`MDBList unified-by-slug early exit - no more items for ${unifiedSlugIdentity.syntheticId} at page ${page}`);
+          return [];
+        }
+      }
+
+      let metas = await parseMDBListItems(response.items, type, language, config, includeVideos);
+      metas = applyAgeRatingFilter(metas, type, config);
+      return metas;
     }
     
     // Handle different watchlist catalog IDs

--- a/addon/tests/mdbListUnified.test.js
+++ b/addon/tests/mdbListUnified.test.js
@@ -1,0 +1,130 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.HOST_NAME = process.env.HOST_NAME || 'http://localhost';
+process.env.NO_CACHE = 'true';
+
+const {
+  buildMDBListItemsBySlugCacheKey,
+  buildMDBListItemsCacheKey,
+  buildSyntheticMDBListUnifiedCatalogId,
+  normalizeMDBListItemsPayload,
+  parseMDBListCatalogUrl,
+  resolveMDBListUnifiedCatalogIdentity,
+} = require('../../dist/utils/mdbList.js');
+
+test('builds a synthetic unified catalog id from username and slug', () => {
+  assert.equal(
+    buildSyntheticMDBListUnifiedCatalogId('nobnobz', 'service-apple-tv'),
+    'mdblist.nobnobz.service-apple-tv.unified'
+  );
+});
+
+test('parses a public MDBList list URL and resolves unified slug identity from metadata', () => {
+  assert.deepEqual(
+    parseMDBListCatalogUrl('https://mdblist.com/lists/nobnobz/service-apple-tv'),
+    { username: 'nobnobz', listSlug: 'service-apple-tv' }
+  );
+
+  assert.deepEqual(
+    resolveMDBListUnifiedCatalogIdentity(
+      {
+        type: 'all',
+        metadata: {
+          username: 'nobnobz',
+          listSlug: 'service-apple-tv',
+        },
+      },
+      'mdblist.nobnobz.service-apple-tv.unified'
+    ),
+    {
+      username: 'nobnobz',
+      listSlug: 'service-apple-tv',
+      syntheticId: 'mdblist.nobnobz.service-apple-tv.unified',
+    }
+  );
+});
+
+test('falls back to metadata.url for legacy mixed MDBList configs', () => {
+  assert.deepEqual(
+    resolveMDBListUnifiedCatalogIdentity(
+      {
+        type: 'all',
+        metadata: {
+          url: 'https://mdblist.com/lists/nobnobz/service-apple-tv',
+        },
+      },
+      'mdblist.12345'
+    ),
+    {
+      username: 'nobnobz',
+      listSlug: 'service-apple-tv',
+      syntheticId: 'mdblist.nobnobz.service-apple-tv.unified',
+    }
+  );
+});
+
+test('does not treat external or split catalogs as unified slug catalogs', () => {
+  assert.equal(
+    resolveMDBListUnifiedCatalogIdentity(
+      {
+        type: 'all',
+        sourceUrl: 'https://api.mdblist.com/external/lists/55/items',
+        metadata: {
+          username: 'nobnobz',
+          listSlug: 'service-apple-tv',
+        },
+      },
+      'mdblist.nobnobz.service-apple-tv.unified'
+    ),
+    null
+  );
+});
+
+test('preserves mixed unified array order and derives a stable local ordinal', () => {
+  const items = normalizeMDBListItemsPayload([
+    { id: 101, mediatype: 'show' },
+    { id: 202, mediatype: 'movie' },
+    { id: 303, mediatype: 'show' },
+  ], 'all');
+
+  assert.deepEqual(
+    items.map(item => [item.id, item.mediatype, item._aiomOrder]),
+    [
+      [101, 'show', 0],
+      [202, 'movie', 1],
+      [303, 'show', 2],
+    ]
+  );
+});
+
+test('keeps legacy movie-only and series-only MDBList payload handling intact', () => {
+  const payload = {
+    movies: [{ id: 1, mediatype: 'movie' }],
+    shows: [{ id: 2, mediatype: 'show' }],
+  };
+
+  assert.deepEqual(
+    normalizeMDBListItemsPayload(payload, 'movie').map(item => item.id),
+    [1]
+  );
+  assert.deepEqual(
+    normalizeMDBListItemsPayload(payload, 'series').map(item => item.id),
+    [2]
+  );
+  assert.deepEqual(
+    normalizeMDBListItemsPayload(payload, 'all').map(item => item.id),
+    [1, 2]
+  );
+});
+
+test('uses a dedicated cache identity for unified slug catalogs', () => {
+  const apiKeyHash = 'hash123';
+  const numericCacheKey = buildMDBListItemsCacheKey(apiKeyHash, '12345', 1, 'rank', 'desc', '', true, 'all', 20);
+  const splitMovieCacheKey = buildMDBListItemsCacheKey(apiKeyHash, '12345', 1, 'rank', 'desc', '', false, 'movie', 20);
+  const unifiedSlugCacheKey = buildMDBListItemsBySlugCacheKey(apiKeyHash, 'nobnobz', 'service-apple-tv', 1, 'rank', 'desc', '', 20);
+
+  assert.notEqual(unifiedSlugCacheKey, numericCacheKey);
+  assert.notEqual(unifiedSlugCacheKey, splitMovieCacheKey);
+  assert.match(unifiedSlugCacheKey, /items-by-slug/);
+});

--- a/addon/utils/mdbList.ts
+++ b/addon/utils/mdbList.ts
@@ -10,6 +10,7 @@ const { socksDispatcher } = require('fetch-socks');
 const { Agent, ProxyAgent } = require('undici');
 
 const logger = consola.withTag('MDBList');
+const MDBLIST_PUBLIC_LIST_URL_PATTERN = /^https?:\/\/(?:www\.)?mdblist\.com\/lists\/([^\/?#]+)\/([^\/?#]+)\/?$/i;
 
 /**
  * Sanitize URL by removing API key for safe logging
@@ -19,6 +20,177 @@ const logger = consola.withTag('MDBList');
 function sanitizeUrlForLogging(url: string): string {
   // Replace API key in query string with [REDACTED]
   return url.replace(/([?&]apikey=)[^&]+/gi, '$1[REDACTED]');
+}
+
+function normalizeMDBListUsername(value?: string): string | undefined {
+  if (!value || typeof value !== 'string') return undefined;
+
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, '');
+  return normalized || undefined;
+}
+
+function normalizeMDBListSlug(value?: string): string | undefined {
+  if (!value || typeof value !== 'string') return undefined;
+
+  const slug = value.trim();
+  return slug || undefined;
+}
+
+function buildSyntheticMDBListUnifiedCatalogId(username: string, listSlug: string): string {
+  return `mdblist.${normalizeMDBListUsername(username) || username}.${normalizeMDBListSlug(listSlug) || listSlug}.unified`;
+}
+
+function parseMDBListCatalogUrl(listUrl?: string): { username: string; listSlug: string } | null {
+  if (!listUrl) return null;
+
+  const match = listUrl.trim().match(MDBLIST_PUBLIC_LIST_URL_PATTERN);
+  if (!match) return null;
+
+  return {
+    username: normalizeMDBListUsername(decodeURIComponent(match[1])) || match[1],
+    listSlug: decodeURIComponent(match[2]),
+  };
+}
+
+function parseSyntheticMDBListUnifiedCatalogId(catalogId?: string): { username: string; listSlug: string } | null {
+  if (!catalogId || !catalogId.startsWith('mdblist.') || !catalogId.endsWith('.unified')) {
+    return null;
+  }
+
+  const identityBody = catalogId.slice('mdblist.'.length, -'.unified'.length);
+  const firstSeparator = identityBody.indexOf('.');
+  if (firstSeparator === -1) {
+    return null;
+  }
+
+  const username = identityBody.slice(0, firstSeparator);
+  const listSlug = identityBody.slice(firstSeparator + 1);
+  if (!username || !listSlug) {
+    return null;
+  }
+
+  return {
+    username,
+    listSlug,
+  };
+}
+
+function resolveMDBListUnifiedCatalogIdentity(catalogConfig?: any, catalogId?: string): { username: string; listSlug: string; syntheticId: string } | null {
+  if (!catalogConfig || catalogConfig.type !== 'all') {
+    return null;
+  }
+
+  if (
+    catalogId === 'mdblist.watchlist' ||
+    catalogId === 'mdblist.upnext' ||
+    catalogId?.startsWith('mdblist.discover.') ||
+    catalogConfig.sourceUrl?.includes('/external/lists/')
+  ) {
+    return null;
+  }
+
+  const metadataUsername = normalizeMDBListUsername(catalogConfig.metadata?.username);
+  const metadataListSlug = normalizeMDBListSlug(catalogConfig.metadata?.listSlug);
+  if (metadataUsername && metadataListSlug) {
+    return {
+      username: metadataUsername,
+      listSlug: metadataListSlug,
+      syntheticId: buildSyntheticMDBListUnifiedCatalogId(metadataUsername, metadataListSlug),
+    };
+  }
+
+  const parsedUrl = parseMDBListCatalogUrl(catalogConfig.metadata?.url);
+  if (parsedUrl) {
+    return {
+      ...parsedUrl,
+      syntheticId: buildSyntheticMDBListUnifiedCatalogId(parsedUrl.username, parsedUrl.listSlug),
+    };
+  }
+
+  const parsedCatalogId = parseSyntheticMDBListUnifiedCatalogId(catalogId);
+  if (parsedCatalogId) {
+    return {
+      ...parsedCatalogId,
+      syntheticId: buildSyntheticMDBListUnifiedCatalogId(parsedCatalogId.username, parsedCatalogId.listSlug),
+    };
+  }
+
+  return null;
+}
+
+function attachStableMDBListOrder(items: any[]): any[] {
+  return items.map((item: any, index: number) => {
+    if (!item || typeof item !== 'object' || item._aiomOrder !== undefined) {
+      return item;
+    }
+
+    return {
+      ...item,
+      _aiomOrder: index,
+    };
+  });
+}
+
+function normalizeMDBListItemsPayload(data: any, catalogType?: string): any[] {
+  const hasMoviesShowsStructure =
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    ('movies' in data || 'shows' in data);
+
+  if (hasMoviesShowsStructure) {
+    if (catalogType === 'series') {
+      return attachStableMDBListOrder(data.shows || []);
+    }
+    if (catalogType === 'movie') {
+      return attachStableMDBListOrder(data.movies || []);
+    }
+
+    // Unified MDBList responses are safest when consumed in provider order.
+    // If the API falls back to separate movie/show buckets instead of a mixed array,
+    // we preserve each bucket's local ordering and assign a deterministic local ordinal
+    // from the combined response position rather than inventing a synthetic popularity score.
+    return attachStableMDBListOrder([
+      ...(data.movies || []),
+      ...(data.shows || [])
+    ]);
+  }
+
+  if (Array.isArray(data)) {
+    return attachStableMDBListOrder(data);
+  }
+
+  return attachStableMDBListOrder([
+    ...(data?.movies || []),
+    ...(data?.shows || [])
+  ]);
+}
+
+function buildMDBListItemsCacheKey(
+  apiKeyHash: string,
+  listId: string,
+  page: number,
+  sort?: string,
+  order?: string,
+  genre?: string,
+  unified?: boolean,
+  catalogType?: string,
+  pageSize?: number
+): string {
+  return `mdblist-api:items:${apiKeyHash}:${listId}:${page}:${sort || ''}:${order || ''}:${genre || ''}:${unified !== false}:${catalogType || ''}:${pageSize || ''}`;
+}
+
+function buildMDBListItemsBySlugCacheKey(
+  apiKeyHash: string,
+  username: string,
+  listSlug: string,
+  page: number,
+  sort?: string,
+  order?: string,
+  genre?: string,
+  pageSize?: number
+): string {
+  return `mdblist-api:items-by-slug:${apiKeyHash}:${normalizeMDBListUsername(username) || username}:${normalizeMDBListSlug(listSlug) || listSlug}:${page}:${sort || ''}:${order || ''}:${genre || ''}:true:all:${pageSize || ''}`;
 }
 
 
@@ -304,7 +476,7 @@ async function fetchMDBListItems(listId: string, apiKey: string, language: strin
   
   const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 16);
   
-  const cacheKey = `mdblist-api:items:${apiKeyHash}:${listId}:${page}:${sort || ''}:${order || ''}:${genre || ''}:${unified !== false}:${catalogType || ''}:${pageSize}`;
+  const cacheKey = buildMDBListItemsCacheKey(apiKeyHash, listId, page, sort, order, genre, unified, catalogType, pageSize);
   
   const ttl = cacheTTL !== undefined ? cacheTTL : parseInt(process.env.CATALOG_TTL || String(1 * 24 * 60 * 60), 10);
   
@@ -355,32 +527,7 @@ async function fetchMDBListItems(listId: string, apiKey: string, language: strin
         totalPages = totalItems ? Math.ceil(totalItems / pageSize) : undefined;
       }
       
-      let items: any[];
-      
-      const hasMoviesShowsStructure = response.data && 
-                                      typeof response.data === 'object' && 
-                                      !Array.isArray(response.data) &&
-                                      ('movies' in response.data || 'shows' in response.data);
-      
-      if (hasMoviesShowsStructure) {
-        if (catalogType === 'series') {
-          items = response.data.shows || [];
-        } else if (catalogType === 'movie') {
-          items = response.data.movies || [];
-        } else {
-          items = [
-            ...(response.data?.movies || []),
-            ...(response.data?.shows || [])
-          ];
-        }
-      } else if (Array.isArray(response.data)) {
-        items = response.data;
-      } else {
-        items = [
-          ...(response.data?.movies || []),
-          ...(response.data?.shows || [])
-        ];
-      }
+      const items = normalizeMDBListItemsPayload(response.data, catalogType);
       
       // Smart pagination validation and logging
       if (listId === 'watchlist') {
@@ -424,6 +571,64 @@ async function fetchMDBListItems(listId: string, apiKey: string, language: strin
       };
     } catch (err: any) {
       logger.error(`Error retrieving items for list ${listId}, page ${page}:`, err.message);
+      return { items: [] };
+    }
+  }, ttl, { skipVersion: true });
+}
+
+async function fetchMDBListItemsBySlug(
+  username: string,
+  listSlug: string,
+  apiKey: string,
+  language: string,
+  page: number,
+  sort?: string,
+  order?: string,
+  genre?: string,
+  cacheTTL?: number
+): Promise<{items: any[], totalItems?: number, hasMore?: boolean, totalPages?: number}> {
+  const pageSize = parseInt(process.env.CATALOG_LIST_ITEMS_SIZE as string) || 20;
+  const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 16);
+  const cacheKey = buildMDBListItemsBySlugCacheKey(apiKeyHash, username, listSlug, page, sort, order, genre, pageSize);
+  const ttl = cacheTTL !== undefined ? cacheTTL : parseInt(process.env.CATALOG_TTL || String(1 * 24 * 60 * 60), 10);
+
+  return await cacheWrapGlobal(cacheKey, async () => {
+    const offset = (page * pageSize) - pageSize;
+
+    try {
+      let url = `https://api.mdblist.com/lists/${encodeURIComponent(username)}/${encodeURIComponent(listSlug)}/items?limit=${pageSize}&offset=${offset}&apikey=${apiKey}&append_to_response=genre,poster&unified=true`;
+
+      if (sort && sort.trim() !== '') {
+        url += `&sort=${sort}`;
+      }
+      if (order && order.trim() !== '') {
+        url += `&order=${order}`;
+      }
+      if (genre && genre.toLowerCase() !== 'none') {
+        url += `&filter_genre=${genre}`;
+      }
+
+      logger.debug(`MDBList unified-by-slug request URL: ${sanitizeUrlForLogging(url)}`);
+
+      const response: any = await makeRateLimitedRequest(
+        () => httpGet(url, { dispatcher: mdblistDispatcher }),
+        apiKey,
+        `MDBList fetchMDBListItemsBySlug (${username}/${listSlug}, page: ${page}, pageSize: ${pageSize}, sort: ${sort}, order: ${order}, genre: ${genre})`
+      );
+
+      const totalItems = response.headers?.['x-total-items'] ? parseInt(response.headers['x-total-items']) : undefined;
+      const hasMore = response.headers?.['x-has-more'] === 'true';
+      const totalPages = totalItems ? Math.ceil(totalItems / pageSize) : undefined;
+      const items = normalizeMDBListItemsPayload(response.data, 'all');
+
+      return {
+        items,
+        totalItems,
+        hasMore,
+        totalPages
+      };
+    } catch (err: any) {
+      logger.error(`Error retrieving unified items for ${username}/${listSlug}, page ${page}:`, err.message);
       return { items: [] };
     }
   }, ttl, { skipVersion: true });
@@ -640,32 +845,7 @@ async function fetchMDBListExternalItems(
 
       const hasMore = response.headers?.['x-has-more'] === 'true';
 
-      let items: any[];
-
-      const hasMoviesShowsStructure = response.data && 
-                                      typeof response.data === 'object' && 
-                                      !Array.isArray(response.data) &&
-                                      ('movies' in response.data || 'shows' in response.data);
-      
-      if (hasMoviesShowsStructure) {
-        if (catalogType === 'series') {
-          items = response.data.shows || [];
-        } else if (catalogType === 'movie') {
-          items = response.data.movies || [];
-        } else {
-          items = [
-            ...(response.data?.movies || []),
-            ...(response.data?.shows || [])
-          ];
-        }
-      } else if (Array.isArray(response.data)) {
-        items = response.data;
-      } else {
-        items = [
-          ...(response.data?.movies || []),
-          ...(response.data?.shows || [])
-        ];
-      }
+      const items = normalizeMDBListItemsPayload(response.data, catalogType);
 
       return { items, hasMore };
     } catch (err: any) {
@@ -1651,6 +1831,10 @@ async function fetchMDBListCatalog(
 }
 
 export {
+  buildMDBListItemsBySlugCacheKey,
+  buildMDBListItemsCacheKey,
+  buildSyntheticMDBListUnifiedCatalogId,
+  fetchMDBListItemsBySlug,
   fetchMDBListItems,
   fetchMDBListExternalItems,
   fetchMDBListBatchMediaInfo,
@@ -1665,9 +1849,12 @@ export {
   testMdblistKey,
   fetchMDBListUpNext,
   parseMDBListUpNextItems,
+  parseMDBListCatalogUrl,
+  parseSyntheticMDBListUnifiedCatalogId,
+  resolveMDBListUnifiedCatalogIdentity,
+  normalizeMDBListItemsPayload,
   fetchMdbListSearchItems,
   checkinMovie,
   checkinEpisode,
   fetchMDBListCatalog
 };
-

--- a/configure/src/components/QuickAddDialog.tsx
+++ b/configure/src/components/QuickAddDialog.tsx
@@ -12,10 +12,12 @@ import { toast } from "sonner";
 import { parseQuickAddUrl, ParsedUrl } from '@/utils/urlParser';
 import { 
   createMDBListCatalog, 
+  createMDBListCatalogsForImport,
   createTraktCatalog, 
   createLetterboxdCatalog, 
   createCustomManifestCatalog,
-  getMdbListType 
+  getMdbListType,
+  groupMDBListListsForImport
 } from '@/utils/catalogUtils';
 import { apiCache } from '@/utils/apiCache';
 
@@ -30,6 +32,7 @@ interface SelectableItem {
   type?: 'movie' | 'series' | 'all';
   itemCount?: number;
   author?: string;
+  supportsUnified?: boolean;
 }
 
 type QuickAddStep = 'input' | 'selection' | 'loading';
@@ -48,6 +51,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
   const [items, setItems] = useState<SelectableItem[]>([]);
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [searchFilter, setSearchFilter] = useState('');
+  const [mixedListUnifiedSettings, setMixedListUnifiedSettings] = useState<Record<string, boolean>>({});
   
   // Store raw list data for proper catalog creation
   const [rawListData, setRawListData] = useState<Map<string, any>>(new Map());
@@ -65,6 +69,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
       setItems([]);
       setSelectedItems(new Set());
       setSearchFilter('');
+      setMixedListUnifiedSettings({});
       setRawListData(new Map());
       setManifest(null);
       setIsLoading(false);
@@ -178,12 +183,25 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
           throw new Error(`Failed to fetch list (Status: ${response.status})`);
         }
 
-        const [list] = await response.json();
-        const catalogId = `mdblist.${list.id}`;
-        
-        if (catalogExists(catalogId)) {
-          toast.info(`List "${list.name}" is already in your catalog list.`);
-          onClose();
+        const rawLists = await response.json();
+        const [list] = groupMDBListListsForImport(Array.isArray(rawLists) ? rawLists : []);
+        if (!list) {
+          throw new Error('List not found');
+        }
+
+        if (getMdbListType(list) === 'all') {
+          setRawListData(new Map([[String(list.id), list]]));
+          setItems([{
+            id: String(list.id),
+            name: list.name,
+            type: 'all',
+            itemCount: list.items,
+            author: list.user_name || parsedUrl.username,
+            supportsUnified: true,
+          }]);
+          setSelectedItems(new Set([String(list.id)]));
+          setMixedListUnifiedSettings({ [String(list.id)]: true });
+          setStep('selection');
           return;
         }
 
@@ -192,6 +210,12 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
           cacheTTL: catalogTTL,
           displayTypeOverrides: config.displayTypeOverrides,
         });
+
+        if (catalogExists(newCatalog.id)) {
+          toast.info(`List "${list.name}" is already in your catalog list.`);
+          onClose();
+          return;
+        }
 
         setConfig(prev => ({
           ...prev,
@@ -216,7 +240,8 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
           throw new Error(`Failed to fetch lists (Status: ${response.status})`);
         }
 
-        const userLists = await response.json();
+        const rawUserLists = await response.json();
+        const userLists = groupMDBListListsForImport(Array.isArray(rawUserLists) ? rawUserLists : []);
         if (!Array.isArray(userLists) || userLists.length === 0) {
           toast.info("No lists found", {
             description: `User "${parsedUrl.username}" has no public lists available`
@@ -230,6 +255,13 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
           listDataMap.set(String(list.id), list);
         });
         setRawListData(listDataMap);
+        const initialUnifiedSettings: Record<string, boolean> = {};
+        userLists.forEach((list: any) => {
+          if (getMdbListType(list) === 'all') {
+            initialUnifiedSettings[String(list.id)] = true;
+          }
+        });
+        setMixedListUnifiedSettings(initialUnifiedSettings);
 
         // Convert to selectable items
         const selectableItems: SelectableItem[] = userLists.map((list: any) => ({
@@ -238,6 +270,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
           type: getMdbListType(list),
           itemCount: list.items,
           author: list.user_name || parsedUrl.username,
+          supportsUnified: getMdbListType(list) === 'all',
         }));
 
         setItems(selectableItems);
@@ -265,9 +298,6 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
       const listsToAdd: CatalogConfig[] = [];
       
       for (const itemId of selectedItems) {
-        const catalogId = `mdblist.${itemId}`;
-        if (catalogExists(catalogId)) continue;
-
         // Use raw list data if available, otherwise fall back to item data
         const rawList = rawListData.get(itemId);
         const item = items.find(i => i.id === itemId);
@@ -275,18 +305,19 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
         if (!rawList && !item) continue;
 
         // Create catalog using raw list data for proper type detection
-        const newCatalog = createMDBListCatalog({
+        const newCatalogs = createMDBListCatalogsForImport({
           list: rawList || {
             id: itemId,
             name: item?.name,
             items: item?.itemCount,
             user_name: item?.author,
           },
+          unified: mixedListUnifiedSettings[itemId] ?? true,
           cacheTTL: catalogTTL,
           displayTypeOverrides: config.displayTypeOverrides,
-        });
+        }).filter(catalog => !catalogExists(catalog.id));
 
-        listsToAdd.push(newCatalog);
+        listsToAdd.push(...newCatalogs);
       }
 
       if (listsToAdd.length > 0) {
@@ -807,6 +838,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
                   setItems([]);
                   setSelectedItems(new Set());
                   setSearchFilter('');
+                  setMixedListUnifiedSettings({});
                   setManifest(null);
                 }}
               >
@@ -856,7 +888,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
                   filteredItems.map((item) => (
                     <div
                       key={item.id}
-                      className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-muted/50"
+                      className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50"
                     >
                       <Switch
                         id={`item-${item.id}`}
@@ -884,6 +916,27 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
                             </span>
                           )}
                         </div>
+                        {item.supportsUnified && (
+                          <div className="flex items-center justify-between mt-2 p-2 border rounded-md bg-muted/50">
+                            <div className="space-y-0.5">
+                              <Label htmlFor={`unified-quickadd-${item.id}`} className="text-sm font-medium">
+                                Unified Format
+                              </Label>
+                              <p className="text-xs text-muted-foreground">
+                                {(mixedListUnifiedSettings[item.id] ?? true)
+                                  ? "Creates one catalog with all items (movies and shows mixed)"
+                                  : "Separate movie and series catalogs"}
+                              </p>
+                            </div>
+                            <Switch
+                              id={`unified-quickadd-${item.id}`}
+                              checked={mixedListUnifiedSettings[item.id] ?? true}
+                              onCheckedChange={(checked) => {
+                                setMixedListUnifiedSettings(prev => ({ ...prev, [item.id]: checked }));
+                              }}
+                            />
+                          </div>
+                        )}
                       </div>
                     </div>
                   ))

--- a/configure/src/components/sections/CatalogsSettings.tsx
+++ b/configure/src/components/sections/CatalogsSettings.tsx
@@ -2145,8 +2145,12 @@ const SortableCatalogItem = ({ catalog, onEditDiscover, onCustomize }: {
                     } else if (catalog.source === 'mdblist') {
                       listUrl = (catalog as any).metadata?.url || null;
                       
-                      if (!listUrl && (catalog as any).metadata?.author && catalog.name) {
-                        // Construct URL from username and list name
+                      if (!listUrl && (catalog as any).metadata?.username && (catalog as any).metadata?.listSlug) {
+                        const username = (catalog as any).metadata.username;
+                        const listSlug = (catalog as any).metadata.listSlug;
+                        listUrl = `https://mdblist.com/lists/${username}/${listSlug}`;
+                      } else if (!listUrl && (catalog as any).metadata?.author && catalog.name) {
+                        // Fallback for legacy configs that only stored the public author/name pair.
                         const username = (catalog as any).metadata.author.toLowerCase().replace(/\s+/g, '');
                         const listSlug = catalog.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
                         listUrl = `https://mdblist.com/lists/${username}/${listSlug}`;

--- a/configure/src/components/sections/MDBListIntegration.tsx
+++ b/configure/src/components/sections/MDBListIntegration.tsx
@@ -12,7 +12,7 @@ import { ChevronDown, Loader2, Plus, Trash2 } from 'lucide-react';
 import { toast } from "sonner";
 import { apiCache } from '@/utils/apiCache';
 import { getGenresBySelection, GenreSelection } from '@/data/genres';
-import { getMdbListType, createMDBListCatalog } from '@/utils/catalogUtils';
+import { getMdbListType, createMDBListCatalog, createMDBListCatalogsForImport, groupMDBListListsForImport } from '@/utils/catalogUtils';
 import type { CatalogConfig } from '@/contexts/ConfigContext';
 
 interface MDBListIntegrationProps {
@@ -40,6 +40,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
   const [topLists, setTopLists] = useState<any[]>([]);
   const [selectedTopLists, setSelectedTopLists] = useState<Set<string>>(new Set());
   const [isLoadingTopLists, setIsLoadingTopLists] = useState(false);
+  const [mixedListUnifiedSettings, setMixedListUnifiedSettings] = useState<Record<string, boolean>>({});
 
   const [externalLists, setExternalLists] = useState<any[]>([]);
   const [selectedExternalLists, setSelectedExternalLists] = useState<Set<string>>(new Set());
@@ -48,6 +49,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
 
   const [userListSort, setUserListSort] = useState<'ranked' | 'name' | 'created'>('ranked');
   const [watchlistUnified, setWatchlistUnified] = useState<boolean>(true);
+  const [singleListUnified, setSingleListUnified] = useState<boolean>(true);
 
   // User info state
   const [userInfo, setUserInfo] = useState<any>(null);
@@ -83,6 +85,16 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     if (!displayTypeOverrides) return undefined;
     return displayTypeOverrides[type];
   };
+
+  const initializeMixedListSettings = useCallback((lists: any[]) => {
+    const defaults: Record<string, boolean> = {};
+    lists.forEach((list: any) => {
+      if (getMdbListType(list) === 'all') {
+        defaults[list.id] = true;
+      }
+    });
+    setMixedListUnifiedSettings(prev => ({ ...prev, ...defaults }));
+  }, []);
   
   // Function to import selected top lists
   const importSelectedTopLists = useCallback(async () => {
@@ -100,21 +112,22 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
           const list = topLists.find(l => l.id === listId);
           if (!list) return;
 
-          const catalogId = `mdblist.${list.id}`;
+          const catalogsToAdd = createMDBListCatalogsForImport({
+            list,
+            unified: mixedListUnifiedSettings[list.id] ?? true,
+            sort: defaultSort,
+            order: defaultOrder,
+            cacheTTL: defaultCacheTTL,
+            genreSelection: defaultGenreSelection,
+            displayTypeOverrides: prev.displayTypeOverrides,
+          });
 
-          // Check if catalog already exists
-          if (!newCatalogs.some(c => c.id === catalogId)) {
-            const newCatalog = createMDBListCatalog({
-              list,
-              sort: defaultSort,
-              order: defaultOrder,
-              cacheTTL: defaultCacheTTL,
-              genreSelection: defaultGenreSelection,
-              displayTypeOverrides: prev.displayTypeOverrides,
-            });
-            newCatalogs.push(newCatalog);
-            newListsAddedCount++;
-          }
+          catalogsToAdd.forEach((newCatalog) => {
+            if (!newCatalogs.some(c => c.id === newCatalog.id)) {
+              newCatalogs.push(newCatalog);
+              newListsAddedCount++;
+            }
+          });
         });
 
         return {
@@ -135,7 +148,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         description: error instanceof Error ? error.message : "Unknown error occurred"
       });
     }
-  }, [selectedTopLists, topLists, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection]);
+  }, [selectedTopLists, topLists, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection, mixedListUnifiedSettings]);
 
   const fetchExternalUserLists = useCallback(async () => {
     if (!tempKey) {
@@ -153,7 +166,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         throw new Error(`Failed to fetch lists (Status: ${response.status})`);
       }
 
-      const userLists = await response.json();
+      const rawUserLists = await response.json();
+      const userLists = groupMDBListListsForImport(Array.isArray(rawUserLists) ? rawUserLists : []);
       if (!Array.isArray(userLists)) {
         throw new Error("Invalid response format from MDBList API");
       }
@@ -250,17 +264,16 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
             }
           } else {
             // Create a single catalog (either unified 'all' or specific 'movie'/'series')
-            const catalogId = `mdblist.${list.id}`;
-            if (!newCatalogs.some(c => c.id === catalogId)) {
-              const newCatalog = createMDBListCatalog({
-                list,
-                sort: defaultSort,
-                order: defaultOrder,
-                cacheTTL: defaultCacheTTL,
-                genreSelection: defaultGenreSelection,
-                displayTypeOverrides: prev.displayTypeOverrides,
-                sourceUrl,
-              });
+            const newCatalog = createMDBListCatalog({
+              list,
+              sort: defaultSort,
+              order: defaultOrder,
+              cacheTTL: defaultCacheTTL,
+              genreSelection: defaultGenreSelection,
+              displayTypeOverrides: prev.displayTypeOverrides,
+              sourceUrl,
+            });
+            if (!newCatalogs.some(c => c.id === newCatalog.id)) {
               newCatalogs.push(newCatalog);
             }
           }
@@ -305,7 +318,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         throw new Error(`Failed to fetch lists (Status: ${response.status})`);
       }
 
-      const userLists = await response.json();
+      const rawUserLists = await response.json();
+      const userLists = groupMDBListListsForImport(Array.isArray(rawUserLists) ? rawUserLists : []);
       if (!Array.isArray(userLists)) {
         throw new Error("Invalid response format from MDBList API");
       }
@@ -323,7 +337,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
           username: username,
           userDescription: popularUsers.find(u => u.username === username)?.description || ""
         }));
-        
+        initializeMixedListSettings(listsWithUser);
         setPopularLists(listsWithUser);
         setSelectedPopularLists(new Set());
         
@@ -340,7 +354,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     } finally {
       setIsLoadingPopularLists(false);
     }
-  }, [tempKey]);
+  }, [tempKey, initializeMixedListSettings]);
 
   const handlePopularListSelection = (listId: string, checked: boolean) => {
     const newSelection = new Set(selectedPopularLists);
@@ -365,7 +379,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         throw new Error("Failed to fetch top lists");
       }
 
-      const topLists = await response.json();
+      const rawTopLists = await response.json();
+      const topLists = groupMDBListListsForImport(Array.isArray(rawTopLists) ? rawTopLists : []);
       if (!Array.isArray(topLists)) {
         throw new Error("Unexpected response format");
       }
@@ -377,6 +392,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         userDescription: `Top list by ${list.user_name || "Unknown"}`
       }));
 
+      initializeMixedListSettings(listsWithUser);
       setTopLists(listsWithUser);
       setSelectedTopLists(new Set());
 
@@ -392,7 +408,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     } finally {
       setIsLoadingTopLists(false);
     }
-  }, [tempKey]);
+  }, [tempKey, initializeMixedListSettings]);
 
   const fetchCustomUserLists = useCallback(async () => {
     if (!tempKey) {
@@ -415,7 +431,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         throw new Error(`Failed to fetch lists (Status: ${response.status})`);
       }
 
-      const userLists = await response.json();
+      const rawUserLists = await response.json();
+      const userLists = groupMDBListListsForImport(Array.isArray(rawUserLists) ? rawUserLists : []);
       if (!Array.isArray(userLists)) {
         throw new Error("Invalid response format from MDBList API");
       }
@@ -426,6 +443,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         });
         setCustomUserLists([]);
       } else {
+        initializeMixedListSettings(userLists);
         setCustomUserLists(userLists);
         setSelectedCustomLists(new Set());
         toast.success("User lists loaded", {
@@ -441,7 +459,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     } finally {
       setIsLoadingCustomUser(false);
     }
-  }, [tempKey, customUsername]);
+  }, [tempKey, customUsername, initializeMixedListSettings]);
 
   const handleCustomListSelection = (listId: string, checked: boolean) => {
     const newSelection = new Set(selectedCustomLists);
@@ -468,21 +486,22 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
           const list = customUserLists.find(l => l.id === listId);
           if (!list) return;
 
-          const catalogId = `mdblist.${list.id}`;
-          
-          // Check if catalog already exists
-          if (!newCatalogs.some(c => c.id === catalogId)) {
-            const newCatalog = createMDBListCatalog({
-              list,
-              sort: defaultSort,
-              order: defaultOrder,
-              cacheTTL: defaultCacheTTL,
-              genreSelection: defaultGenreSelection,
-              displayTypeOverrides: prev.displayTypeOverrides,
-            });
-            newCatalogs.push(newCatalog);
-            newListsAddedCount++;
-          }
+          const catalogsToAdd = createMDBListCatalogsForImport({
+            list,
+            unified: mixedListUnifiedSettings[list.id] ?? true,
+            sort: defaultSort,
+            order: defaultOrder,
+            cacheTTL: defaultCacheTTL,
+            genreSelection: defaultGenreSelection,
+            displayTypeOverrides: prev.displayTypeOverrides,
+          });
+
+          catalogsToAdd.forEach((newCatalog) => {
+            if (!newCatalogs.some(c => c.id === newCatalog.id)) {
+              newCatalogs.push(newCatalog);
+              newListsAddedCount++;
+            }
+          });
         });
 
         return {
@@ -504,7 +523,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         description: error instanceof Error ? error.message : "Unknown error occurred"
       });
     }
-  }, [selectedCustomLists, customUserLists, customUsername, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection]);
+  }, [selectedCustomLists, customUserLists, customUsername, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection, mixedListUnifiedSettings]);
 
   const importSelectedPopularLists = useCallback(async () => {
     if (selectedPopularLists.size === 0) {
@@ -521,21 +540,22 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
           const list = popularLists.find(l => l.id === listId);
           if (!list) return;
 
-          const catalogId = `mdblist.${list.id}`;
-          
-          // Check if catalog already exists
-          if (!newCatalogs.some(c => c.id === catalogId)) {
-            const newCatalog = createMDBListCatalog({
-              list,
-              sort: defaultSort,
-              order: defaultOrder,
-              cacheTTL: defaultCacheTTL,
-              genreSelection: defaultGenreSelection,
-              displayTypeOverrides: prev.displayTypeOverrides,
-            });
-            newCatalogs.push(newCatalog);
-            newListsAddedCount++;
-          }
+          const catalogsToAdd = createMDBListCatalogsForImport({
+            list,
+            unified: mixedListUnifiedSettings[list.id] ?? true,
+            sort: defaultSort,
+            order: defaultOrder,
+            cacheTTL: defaultCacheTTL,
+            genreSelection: defaultGenreSelection,
+            displayTypeOverrides: prev.displayTypeOverrides,
+          });
+
+          catalogsToAdd.forEach((newCatalog) => {
+            if (!newCatalogs.some(c => c.id === newCatalog.id)) {
+              newCatalogs.push(newCatalog);
+              newListsAddedCount++;
+            }
+          });
         });
 
         return {
@@ -557,7 +577,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         description: error instanceof Error ? error.message : "Unknown error occurred"
       });
     }
-  }, [selectedPopularLists, popularLists, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection]);
+  }, [selectedPopularLists, popularLists, setConfig, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection, mixedListUnifiedSettings]);
 
   const validateApiKey = useCallback(async (isRefresh = false) => {
     if (!tempKey) {
@@ -592,46 +612,51 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         );
 
         // Process each list from the API
-        listsFromApi.forEach((list: any) => {
-          const type = getMdbListType(list);
-          const catalogId = `mdblist.${list.id}`;
-          const catalogKey = `${catalogId}-${type}`;
+        groupMDBListListsForImport(Array.isArray(listsFromApi) ? listsFromApi : []).forEach((list: any) => {
+          const candidateCatalogs = createMDBListCatalogsForImport({
+            list,
+            unified: mixedListUnifiedSettings[list.id] ?? true,
+            sort: defaultSort,
+            order: defaultOrder,
+            cacheTTL: defaultCacheTTL,
+            genreSelection: defaultGenreSelection,
+            displayTypeOverrides: prev.displayTypeOverrides,
+          });
+          const candidateKeys = candidateCatalogs.map(catalog => `${catalog.id}-${catalog.type}`);
+          const splitEntries = Array.isArray(list?._groupedEntries) ? list._groupedEntries : [];
+          const splitExists = splitEntries.length > 0 && splitEntries.every((entry: any) => {
+            const entryType = entry.mediatype === 'movie' ? 'movie' : 'series';
+            return existingMdbListIds.has(`mdblist.${entry.id}-${entryType}`);
+          });
           
           // Check if catalog already exists
-          if (!existingMdbListIds.has(catalogKey)) {
+          if (!candidateKeys.every(key => existingMdbListIds.has(key)) && !splitExists) {
             // Add new catalog at the end
-            const newCatalog = createMDBListCatalog({
-              list,
-              sort: defaultSort,
-              order: defaultOrder,
-              cacheTTL: defaultCacheTTL,
-              genreSelection: defaultGenreSelection,
-              displayTypeOverrides: prev.displayTypeOverrides,
+            candidateCatalogs.forEach((newCatalog) => {
+              newCatalogs.push(newCatalog);
+              newListsAddedCount++;
             });
-            newCatalogs.push(newCatalog);
-            newListsAddedCount++;
           } else {
-            // Catalog exists, update its properties but keep position
-            const existingCatalogIndex = newCatalogs.findIndex(c => c.id === catalogId && c.type === type);
-            if (existingCatalogIndex !== -1) {
-              const existingCatalog = newCatalogs[existingCatalogIndex];
-              // Only restore if it was disabled
-              if (!existingCatalog.enabled) {
-                newCatalogs[existingCatalogIndex] = {
-                  ...existingCatalog,
-                  enabled: true,
-                  showInHome: true,
-                  name: list.name, // Update name in case it changed
-                };
-                restoredListsCount++;
-              } else {
-                // Just update the name in case it changed
-                newCatalogs[existingCatalogIndex] = {
-                  ...existingCatalog,
-                  name: list.name,
-                };
+            candidateCatalogs.forEach((newCatalog) => {
+              const existingCatalogIndex = newCatalogs.findIndex(c => c.id === newCatalog.id && c.type === newCatalog.type);
+              if (existingCatalogIndex !== -1) {
+                const existingCatalog = newCatalogs[existingCatalogIndex];
+                if (!existingCatalog.enabled) {
+                  newCatalogs[existingCatalogIndex] = {
+                    ...existingCatalog,
+                    enabled: true,
+                    showInHome: true,
+                    name: newCatalog.name,
+                  };
+                  restoredListsCount++;
+                } else {
+                  newCatalogs[existingCatalogIndex] = {
+                    ...existingCatalog,
+                    name: newCatalog.name,
+                  };
+                }
               }
-            }
+            });
           }
         });
 
@@ -670,7 +695,7 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     } finally {
       setIsChecking(false);
     }
-  }, [setConfig, tempKey, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection]);
+  }, [setConfig, tempKey, defaultSort, defaultOrder, defaultCacheTTL, defaultGenreSelection, mixedListUnifiedSettings]);
 
   const handleSave = () => {
     if (isValid) {
@@ -696,7 +721,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
       const response = await fetch(`/api/mdblist/lists/${encodeURIComponent(username)}/${encodeURIComponent(listname)}?apikey=${tempKey}`);
       if (!response.ok) throw new Error(`Error fetching list (Status: ${response.status})`);
 
-      const lists = await response.json();
+      const rawLists = await response.json();
+      const lists = groupMDBListListsForImport(Array.isArray(rawLists) ? rawLists : []);
       if (!Array.isArray(lists) || lists.length === 0) {
         throw new Error("No lists found in the response.");
       }
@@ -707,8 +733,9 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
         let skippedCount = 0;
 
         lists.forEach((list: any) => {
-          const newCatalog = createMDBListCatalog({
+          const catalogsToAdd = createMDBListCatalogsForImport({
             list,
+            unified: singleListUnified,
             sort: defaultSort,
             order: defaultOrder,
             cacheTTL: defaultCacheTTL,
@@ -717,14 +744,14 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
             listUrl: customListUrl,
           });
 
-          // Prevent duplicates
-          if (prev.catalogs.some(c => c.id === newCatalog.id)) {
-            skippedCount++;
-            return;
-          }
-          
-          newCatalogs.push(newCatalog);
-          addedCount++;
+          catalogsToAdd.forEach((newCatalog) => {
+            if (prev.catalogs.some(c => c.id === newCatalog.id)) {
+              skippedCount++;
+              return;
+            }
+            newCatalogs.push(newCatalog);
+            addedCount++;
+          });
         });
 
         if (addedCount === 0) {
@@ -1336,12 +1363,17 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                           onCheckedChange={(checked) => handleCustomListSelection(list.id, checked)}
                         />
                         <div className="flex-1 min-w-0">
+                          {(() => {
+                            const listType = getMdbListType(list);
+                            const isMixedType = listType === 'all';
+                            return (
+                              <>
                           <Label htmlFor={`custom-${list.id}`} className="font-medium cursor-pointer">
                             {list.name}
                           </Label>
                           <div className="flex items-center gap-2 mt-1">
                             <Badge variant="outline" className="text-xs capitalize">
-                              {list.mediatype}
+                              {listType}
                             </Badge>
                             <Badge variant="secondary" className="text-xs">
                               by {customUsername}
@@ -1357,6 +1389,30 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                               {list.description}
                             </p>
                           )}
+                          {isMixedType && (
+                            <div className="flex items-center justify-between mt-2 p-2 border rounded-md bg-muted/50">
+                              <div className="space-y-0.5">
+                                <Label htmlFor={`mixed-custom-${list.id}`} className="text-sm font-medium">
+                                  Unified Format
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                  {(mixedListUnifiedSettings[list.id] ?? true)
+                                    ? "Creates one catalog with all items (movies and shows mixed)"
+                                    : "Separate movie and series catalogs"}
+                                </p>
+                              </div>
+                              <Switch
+                                id={`mixed-custom-${list.id}`}
+                                checked={mixedListUnifiedSettings[list.id] ?? true}
+                                onCheckedChange={(checked) => {
+                                  setMixedListUnifiedSettings(prev => ({ ...prev, [list.id]: checked }));
+                                }}
+                              />
+                            </div>
+                          )}
+                              </>
+                            );
+                          })()}
                         </div>
                       </div>
                     ))}
@@ -1387,9 +1443,26 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                 </CardDescription>
               </CardHeader>
               <CardContent>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="single-list-unified" className="text-sm font-medium">
+                        Unified Format
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        Mixed MDBList lists can be imported as one mixed catalog or split into movies and series.
+                      </p>
+                    </div>
+                    <Switch
+                      id="single-list-unified"
+                      checked={singleListUnified}
+                      onCheckedChange={setSingleListUnified}
+                    />
+                  </div>
                 <div className="flex items-center space-x-2">
                   <Input id="customListUrl" value={customListUrl} onChange={(e) => setCustomListUrl(e.target.value)} placeholder="https://mdblist.com/lists/user/list-name" />
                   <Button onClick={handleAddCustomList} variant="outline">Add</Button>
+                </div>
                 </div>
               </CardContent>
             </Card>
@@ -1527,12 +1600,17 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                           onCheckedChange={(checked) => handlePopularListSelection(list.id, checked)}
                         />
                         <div className="flex-1 min-w-0">
+                          {(() => {
+                            const listType = getMdbListType(list);
+                            const isMixedType = listType === 'all';
+                            return (
+                              <>
                           <Label htmlFor={list.id} className="font-medium cursor-pointer">
                             {list.name}
                           </Label>
                           <div className="flex items-center gap-2 mt-1">
                             <Badge variant="outline" className="text-xs capitalize">
-                              {list.mediatype}
+                              {listType}
                             </Badge>
                             <Badge variant="secondary" className="text-xs">
                               by {list.user}
@@ -1548,6 +1626,30 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                               {list.description}
                             </p>
                           )}
+                          {isMixedType && (
+                            <div className="flex items-center justify-between mt-2 p-2 border rounded-md bg-muted/50">
+                              <div className="space-y-0.5">
+                                <Label htmlFor={`mixed-popular-${list.id}`} className="text-sm font-medium">
+                                  Unified Format
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                  {(mixedListUnifiedSettings[list.id] ?? true)
+                                    ? "Creates one catalog with all items (movies and shows mixed)"
+                                    : "Separate movie and series catalogs"}
+                                </p>
+                              </div>
+                              <Switch
+                                id={`mixed-popular-${list.id}`}
+                                checked={mixedListUnifiedSettings[list.id] ?? true}
+                                onCheckedChange={(checked) => {
+                                  setMixedListUnifiedSettings(prev => ({ ...prev, [list.id]: checked }));
+                                }}
+                              />
+                            </div>
+                          )}
+                              </>
+                            );
+                          })()}
                         </div>
                       </div>
                     ))}
@@ -1637,12 +1739,17 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                             }}
                           />
                           <div className="flex-1 min-w-0">
+                            {(() => {
+                              const listType = getMdbListType(list);
+                              const isMixedType = listType === 'all';
+                              return (
+                                <>
                             <Label htmlFor={`top-${list.id}`} className="font-medium cursor-pointer">
                               {list.name}
                             </Label>
                             <div className="flex items-center gap-2 mt-1">
                               <Badge variant="outline" className="text-xs capitalize">
-                                {list.mediatype}
+                                {listType}
                               </Badge>
                               <Badge variant="secondary" className="text-xs">
                                 by {list.user}
@@ -1658,6 +1765,30 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                                 {list.description}
                               </p>
                             )}
+                            {isMixedType && (
+                              <div className="flex items-center justify-between mt-2 p-2 border rounded-md bg-muted/50">
+                                <div className="space-y-0.5">
+                                  <Label htmlFor={`mixed-top-${list.id}`} className="text-sm font-medium">
+                                    Unified Format
+                                  </Label>
+                                  <p className="text-xs text-muted-foreground">
+                                    {(mixedListUnifiedSettings[list.id] ?? true)
+                                      ? "Creates one catalog with all items (movies and shows mixed)"
+                                      : "Separate movie and series catalogs"}
+                                  </p>
+                                </div>
+                                <Switch
+                                  id={`mixed-top-${list.id}`}
+                                  checked={mixedListUnifiedSettings[list.id] ?? true}
+                                  onCheckedChange={(checked) => {
+                                    setMixedListUnifiedSettings(prev => ({ ...prev, [list.id]: checked }));
+                                  }}
+                                />
+                              </div>
+                            )}
+                                </>
+                              );
+                            })()}
                           </div>
                         </div>
                       ))}
@@ -1770,8 +1901,8 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
                                   <Label htmlFor={`unified-switch-${list.id}`} className="text-sm font-medium">Unified Format</Label>
                                   <p className="text-xs text-muted-foreground">
                                     {externalUnifiedSettings[list.id] ?? true
-                                      ? "One catalog for all media types"
-                                      : "Separate catalogs for movies & series"}
+                                      ? "Creates one catalog with all items (movies and shows mixed)"
+                                      : "Separate movie and series catalogs"}
                                   </p>
                                 </div>
                                 <Switch
@@ -1828,4 +1959,3 @@ export function MDBListIntegration({ isOpen, onClose }: MDBListIntegrationProps)
     </Dialog>
   );
 }
-

--- a/configure/src/contexts/config.ts
+++ b/configure/src/contexts/config.ts
@@ -34,8 +34,11 @@ export interface CatalogConfig {
     privacy?: string;
     author?: string;
     description?: string;
+    mediatype?: string;
+    unified?: boolean;
     // AniList-specific metadata
     username?: string;
+    listSlug?: string;
     listName?: string;
     isCustomList?: boolean;
     // Trakt Up Next metadata

--- a/configure/src/lib/catalogShare.ts
+++ b/configure/src/lib/catalogShare.ts
@@ -69,7 +69,9 @@ function sanitizeMetadata(metadata: CatalogConfig['metadata']): CatalogConfig['m
   if (metadata.isWatchlist !== undefined) safe.isWatchlist = metadata.isWatchlist;
   if (metadata.isCustomList !== undefined) safe.isCustomList = metadata.isCustomList;
   if ((metadata as any).mediatype) safe.mediatype = (metadata as any).mediatype;
+  if ((metadata as any).unified !== undefined) safe.unified = (metadata as any).unified;
   if (metadata.username) safe.username = metadata.username;
+  if ((metadata as any).listSlug) safe.listSlug = (metadata as any).listSlug;
   if (metadata.listName) safe.listName = metadata.listName;
   if (metadata.author) safe.author = metadata.author;
   if (metadata.listId) safe.listId = metadata.listId;

--- a/configure/src/utils/catalogUtils.ts
+++ b/configure/src/utils/catalogUtils.ts
@@ -6,6 +6,8 @@
 import { CatalogConfig } from '@/contexts/ConfigContext';
 import { GenreSelection } from '@/data/genres';
 
+const MDBLIST_LIST_URL_PATTERN = /^https?:\/\/(?:www\.)?mdblist\.com\/lists\/([^\/?#]+)\/([^\/?#]+)\/?$/i;
+
 /**
  * Determines the catalog type based on MDBList list metadata
  * @param list - MDBList list object with mediatype, movies, shows, items properties
@@ -36,6 +38,140 @@ export function getMdbListType(list: any): 'movie' | 'series' | 'all' {
   return 'all';
 }
 
+function normalizeMDBListUsername(value?: string): string | undefined {
+  if (!value || typeof value !== 'string') return undefined;
+
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, '');
+  return normalized || undefined;
+}
+
+function slugifyMDBListListName(value?: string): string | undefined {
+  if (!value || typeof value !== 'string') return undefined;
+
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return slug || undefined;
+}
+
+export function parseMDBListCatalogUrl(listUrl?: string): { username: string; listSlug: string } | null {
+  if (!listUrl) return null;
+
+  const match = listUrl.trim().match(MDBLIST_LIST_URL_PATTERN);
+  if (!match) return null;
+
+  return {
+    username: normalizeMDBListUsername(decodeURIComponent(match[1])) || match[1],
+    listSlug: decodeURIComponent(match[2]),
+  };
+}
+
+export function getMDBListCatalogIdentity(list: any, listUrl?: string): { username?: string; listSlug?: string } {
+  const parsedUrl = parseMDBListCatalogUrl(listUrl);
+  const username =
+    parsedUrl?.username ||
+    normalizeMDBListUsername(list.user_name) ||
+    normalizeMDBListUsername(list.user);
+  const listSlug =
+    parsedUrl?.listSlug ||
+    (typeof list.slug === 'string' && list.slug.trim() ? list.slug.trim() : undefined) ||
+    slugifyMDBListListName(list.name);
+
+  return {
+    username,
+    listSlug,
+  };
+}
+
+export function buildSyntheticMDBListUnifiedCatalogId(username: string, listSlug: string): string {
+  return `mdblist.${normalizeMDBListUsername(username) || username}.${listSlug}.unified`;
+}
+
+export function getMDBListCatalogId(list: any, sourceUrl?: string, listUrl?: string): string {
+  const type = getMdbListType(list);
+  const { username, listSlug } = getMDBListCatalogIdentity(list, listUrl);
+  const isExternalList = !!sourceUrl && sourceUrl.includes('/external/lists/');
+
+  if (type === 'all' && !isExternalList && username && listSlug) {
+    return buildSyntheticMDBListUnifiedCatalogId(username, listSlug);
+  }
+
+  return `mdblist.${list.id}`;
+}
+
+function getMDBListGroupingIdentity(list: any): string {
+  const { username, listSlug } = getMDBListCatalogIdentity(list);
+
+  if (username && listSlug) {
+    return `${username}:${listSlug}`;
+  }
+
+  if (list.slug) {
+    return String(list.slug);
+  }
+
+  return `${list.user_name || list.user || 'unknown'}:${list.name || list.id}`;
+}
+
+/**
+ * MDBList exposes some mixed dynamic lists as two sibling list metadata entries
+ * (one movie, one show) that share the same public username/slug. We collapse
+ * those pairs into a single synthetic mixed definition for import flows so the
+ * catalog can later resolve through the unified items endpoint.
+ */
+export function groupMDBListListsForImport(lists: any[]): any[] {
+  const grouped = new Map<string, any[]>();
+
+  lists.forEach((list: any) => {
+    const key = getMDBListGroupingIdentity(list);
+    const entries = grouped.get(key);
+    if (entries) {
+      entries.push(list);
+    } else {
+      grouped.set(key, [list]);
+    }
+  });
+
+  return Array.from(grouped.values()).map((entries) => {
+    if (entries.length === 1) {
+      return entries[0];
+    }
+
+    const hasMovie = entries.some(entry => entry.mediatype === 'movie');
+    const hasShow = entries.some(entry => entry.mediatype === 'show');
+
+    if (!hasMovie || !hasShow) {
+      return entries[0];
+    }
+
+    const first = entries[0];
+    const totals = entries.reduce((acc, entry) => {
+      const itemCount = Number(entry.items ?? 0);
+      if (entry.mediatype === 'movie') {
+        acc.movies += Number(entry.movies ?? itemCount);
+      } else if (entry.mediatype === 'show') {
+        acc.shows += Number(entry.shows ?? entry.items_show ?? itemCount);
+      }
+      acc.items += itemCount;
+      return acc;
+    }, { items: 0, movies: 0, shows: 0 });
+
+    return {
+      ...first,
+      id: `unified:${getMDBListGroupingIdentity(first)}`,
+      mediatype: undefined,
+      items: totals.items,
+      movies: totals.movies,
+      shows: totals.shows,
+      items_show: totals.shows,
+      _groupedEntries: entries,
+    };
+  });
+}
+
 /**
  * Gets the display type override based on catalog type and user preferences
  */
@@ -64,6 +200,10 @@ export interface MDBListCatalogOptions {
   listUrl?: string; // URL to the list on mdblist.com
 }
 
+export interface MDBListCatalogImportOptions extends MDBListCatalogOptions {
+  unified?: boolean;
+}
+
 /**
  * Creates an MDBList catalog configuration
  * @param options - Configuration options for the MDBList catalog
@@ -83,18 +223,17 @@ export function createMDBListCatalog(options: MDBListCatalogOptions): CatalogCon
 
   const type = getMdbListType(list);
   const displayType = getDisplayTypeOverride(type, displayTypeOverrides);
+  const identity = getMDBListCatalogIdentity(list, listUrl);
+  const catalogId = getMDBListCatalogId(list, sourceUrl, listUrl);
 
   // Construct list URL if not provided but we have username/list info
   let finalListUrl = listUrl;
-  if (!finalListUrl && list.user_name && list.name) {
-    // Construct URL from username and list name/slug
-    const username = list.user_name.toLowerCase().replace(/\s+/g, '');
-    const listSlug = list.slug || list.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-    finalListUrl = `https://mdblist.com/lists/${username}/${listSlug}`;
+  if (!finalListUrl && identity.username && identity.listSlug) {
+    finalListUrl = `https://mdblist.com/lists/${identity.username}/${identity.listSlug}`;
   }
 
   return {
-    id: `mdblist.${list.id}`,
+    id: catalogId,
     type,
     name: list.name,
     enabled: true,
@@ -109,11 +248,63 @@ export function createMDBListCatalog(options: MDBListCatalogOptions): CatalogCon
     ...(sourceUrl && { sourceUrl }),
     metadata: {
       ...(list.items !== undefined && { itemCount: list.items }),
-      ...(list.user_name ? { author: list.user_name } : {}),
+      ...(list.user_name || identity.username ? { author: list.user_name || identity.username } : {}),
       ...(finalListUrl && { url: finalListUrl }),
+      ...(identity.username && { username: identity.username }),
+      ...(identity.listSlug && { listSlug: identity.listSlug }),
       ...(list.mediatype && { mediatype: list.mediatype }),
+      ...(type === 'all' && identity.username && identity.listSlug ? { unified: true } : {}),
     },
   };
+}
+
+export function createMDBListCatalogsForImport(options: MDBListCatalogImportOptions): CatalogConfig[] {
+  const { list, unified = true } = options;
+  const listType = getMdbListType(list);
+
+  if (listType !== 'all' || unified) {
+    return [createMDBListCatalog(options)];
+  }
+
+  const groupedEntries = Array.isArray(list?._groupedEntries) ? list._groupedEntries : [];
+  const splitEntries = groupedEntries.filter((entry: any) => entry?.mediatype === 'movie' || entry?.mediatype === 'show');
+
+  if (splitEntries.length > 0) {
+    return splitEntries.map((entry: any) => createMDBListCatalog({
+      ...options,
+      list: entry,
+    }));
+  }
+
+  const movieCatalog = createMDBListCatalog({
+    ...options,
+    list: {
+      ...list,
+      id: `${list.id}.movies`,
+      name: `${list.name} (Movies)`,
+      mediatype: 'movie',
+      items: Number(list.movies ?? 0),
+      movies: Number(list.movies ?? 0),
+      shows: 0,
+      items_show: 0,
+    },
+  });
+
+  const seriesCatalog = createMDBListCatalog({
+    ...options,
+    list: {
+      ...list,
+      id: `${list.id}.series`,
+      name: `${list.name} (Series)`,
+      mediatype: 'show',
+      items: Number(list.shows ?? list.items_show ?? 0),
+      movies: 0,
+      shows: Number(list.shows ?? list.items_show ?? 0),
+      items_show: Number(list.shows ?? list.items_show ?? 0),
+    },
+  });
+
+  return [movieCatalog, seriesCatalog];
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #415

## Summary

This adds proper support for mixed MDBList dynamic lists queried through the unified items endpoint.

MDBList can expose mixed lists as separate movie/show metadata entries for the same public `username/slug`, while the actual mixed content is available from `/lists/{username}/{slug}/items?unified=true`.

This change adds a unified import and resolution path so mixed MDBList lists can be consumed as a single `all` catalog instead of being split into separate movie and series catalogs.

## What changed

- group MDBList sibling list metadata entries by `username/slug` during import flows
- add a synthetic internal catalog id for unified mixed catalogs: `mdblist.{username}.{slug}.unified`
- fetch mixed MDBList items through the unified items endpoint
- preserve per-item `mediatype` when normalizing the mixed response
- keep response order stable for unified mixed catalogs instead of inventing synthetic popularity values
- add UI support to choose between one unified mixed catalog or separate movie and series catalogs
- keep existing movie-only and series-only MDBList flows unchanged
- ignore local generated addon runtime data so SQLite/cache files do not get committed accidentally

## Notes

- MDBList does not expose a dedicated unified numeric list id for these mixed lists, so the addon uses a synthetic internal identity.
- Unified mixed ordering preserves the original API response order. If an explicit internal order is needed, it is derived from response position only.

## Validation

- `node --test --test-force-exit addon/tests/mdbListUnified.test.js`
- frontend build verified locally
- backend build verified locally
- local/live smoke checks against MDBList mixed list responses during development
