### PR TITLE
chore: update .gitignore for bun lockfiles and addon/data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ dist
 *.save
 *.save.*
 temp/
+
+# Runtime generated files
+addon/data/*
+!addon/data/id-mapping-corrections.json

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Bun lockfile
+bun.lockb
+bun.lock
+
 # dotenv environment variables file
 .env
 .env.test


### PR DESCRIPTION
## Summary

Updates `.gitignore` to ignore Bun lockfiles and runtime generated files in `addon/data/`, while keeping `id-mapping-corrections.json` tracked.

## Changes

- Add `bun.lockb` and `bun.lock` to ignored files
- Ignore `addon/data/*` but allowlist `addon/data/id-mapping-corrections.json`