### PR TITLE
fix: reduce redis RDB snapshot frequency to prevent excessive disk writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ services:
     restart: unless-stopped
     volumes:
       - ${DOCKER_DATA_DIR}/aiometadata/cache:/data
-    command: redis-server --appendonly yes --save 60 1
+    command: redis-server --appendonly yes --save 3600 1
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary

The Redis `--save 60 1` flag causes an RDB snapshot to be written to disk whenever at least 1 key changes within a 60 second window. Combined with `--appendonly yes` (AOF), RDB snapshots are largely redundant for crash recovery, but the real issue is that anyone copying this config as is will silently hammer their disk. With a large dataset, this means rewriting hundreds of megabytes to disk every minute, even for a single self-hosted user with normal activity.

Changing to `--save 3600 1` reduces this to hourly snapshots, which is a far more reasonable default for a self-hosted setup while still providing a recoverable restore point alongside AOF.

## Changes

- Change `--save 60 1` to `--save 3600 1` in Redis command args