### PR TITLE
feat(httpClient): set a default ttl for dns lookups

### DIFF
--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
-const { request, Agent, ProxyAgent } = require("undici");
+const { request } = require("undici");
+const { createDispatcher } = require('../utils/httpClient');
 const database = require('./database');
 const buildInfo = require('./buildInfo');
 const KEY_VALIDATION_STATUS_SET = new Set(['valid', 'invalid', 'timeout', 'error']);
@@ -11,36 +12,13 @@ const TEST_API_KEY_MAX_LENGTH = (() => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 128;
 })();
 
-// Gemini dispatcher configuration for API key testing
-// Priority: GEMINI_HTTPS_PROXY/GEMINI_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct connection
-const createGeminiDispatcher = () => {
-  // First check for Gemini-specific proxy
-  const geminiProxy = process.env.GEMINI_HTTPS_PROXY ?? process.env.GEMINI_HTTP_PROXY;
-  if (geminiProxy) {
-    try {
-      return new ProxyAgent({ uri: new URL(geminiProxy).toString(), allowH2: false });
-    } catch (error) {
-      console.warn("Invalid Gemini proxy URL:", geminiProxy);
-    }
-  }
-  // Fall back to global proxy
-  const globalProxy = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-  if (globalProxy) {
-    try {
-      return new ProxyAgent({ uri: new URL(globalProxy).toString(), allowH2: false });
-    } catch (error) {
-      console.warn("Invalid global proxy URL:", globalProxy);
-    }
-  }
-  // No proxy configured - use direct connection
-  return new Agent({
-    allowH2: false,
-    keepAliveTimeout: 10000,
-    connections: 10,
-  });
-};
-
-const geminiDispatcher = createGeminiDispatcher();
+// Gemini dispatcher
+// priority: GEMINI_HTTPS_PROXY/GEMINI_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct
+const geminiDispatcher = createDispatcher({
+  label: 'Gemini',
+  proxyEnvVars: ['GEMINI_HTTPS_PROXY', 'GEMINI_HTTP_PROXY', 'HTTPS_PROXY', 'HTTP_PROXY'],
+  agentOptions: { keepAliveTimeout: 10_000, connections: 10 },
+});
 const consola = require('consola');
 
 const logger = consola.withTag('ConfigApi');

--- a/addon/lib/getTmdb.ts
+++ b/addon/lib/getTmdb.ts
@@ -1,5 +1,5 @@
-import { fetch, Agent, ProxyAgent } from 'undici';
-import { socksDispatcher } from 'fetch-socks';
+import { fetch } from 'undici';
+import { createDispatcher } from '../utils/httpClient.js';
 import { scrapeSingleImdbResultByTitle, getMetaFromImdbIo } from './imdb';
 import requestTracker from './requestTracker';
 import consola from 'consola';
@@ -49,47 +49,13 @@ function selectTmdbImageByLang(images: TmdbImage[] | undefined, config: UserConf
   return best || fallbackEn || fallbackAny || undefined;
 }
 
-// TMDB dispatcher configuration
-const SOCKS_PROXY_URL = process.env.TMDB_SOCKS_PROXY_URL;
-const HTTP_PROXY_URL = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-let dispatcher: any;
-
-if (SOCKS_PROXY_URL) {
-  try {
-    const proxyUrlObj = new URL(SOCKS_PROXY_URL);
-    if (proxyUrlObj.protocol === 'socks5:' || proxyUrlObj.protocol === 'socks4:') {
-      dispatcher = socksDispatcher({
-        type: proxyUrlObj.protocol === 'socks5:' ? 5 : 4,
-        host: proxyUrlObj.hostname,
-        port: parseInt(proxyUrlObj.port),
-        userId: proxyUrlObj.username,
-        password: proxyUrlObj.password,
-      });
-      consola.info(`[TMDB] SOCKS proxy is enabled for undici via fetch-socks.`);
-    } else {
-      console.error(`[TMDB] Unsupported proxy protocol: ${proxyUrlObj.protocol}. Falling back.`);
-      dispatcher = null;
-    }
-  } catch (error: any) {
-    console.error(`[TMDB] Invalid SOCKS_PROXY_URL. Falling back. Error: ${error.message}`);
-    dispatcher = null;
-  }
-}
-
-if (!dispatcher) {
-  if (HTTP_PROXY_URL) {
-    try {
-      dispatcher = new ProxyAgent({ uri: new URL(HTTP_PROXY_URL).toString(), allowH2: false });
-      console.log('[TMDB] Using global HTTP proxy.');
-    } catch (error: any) {
-      console.error(`[TMDB] Invalid HTTP_PROXY URL. Using direct connection. Error: ${error.message}`);
-      dispatcher = new Agent({ allowH2: false, connect: { timeout: 10000 } });
-    }
-  } else {
-    dispatcher = new Agent({ allowH2: false, connect: { timeout: 10000 } });
-    console.log('[TMDB] undici agent is enabled for direct connections.');
-  }
-}
+// TMDB dispatcher
+// priority: TMDB_SOCKS_PROXY_URL > HTTPS_PROXY/HTTP_PROXY > direct
+const dispatcher = createDispatcher({
+  label: 'TMDB',
+  socksProxyEnvVar: 'TMDB_SOCKS_PROXY_URL',
+  agentOptions: { connect: { timeout: 10_000 } },
+});
 
 // Simple cache for scraped IDs to avoid re-scraping
 const scrapedImdbIdCache = new Map<string, string>();

--- a/addon/lib/mal.js
+++ b/addon/lib/mal.js
@@ -1,7 +1,5 @@
 require("dotenv").config();
-const { httpGet } = require('../utils/httpClient');
-const { socksDispatcher } = require('fetch-socks');
-const { Agent, ProxyAgent } = require('undici');
+const { httpGet, createDispatcher } = require('../utils/httpClient');
 const consola = require('consola');
 const redis = require('./redisClient');
 const logger = consola.withTag('MAL');
@@ -29,49 +27,13 @@ setInterval(() => {
   }
 }, 60 * 60 * 1000); // Run every hour
 
-// MAL/Jikan dispatcher configuration
-// Priority: MAL_SOCKS_PROXY_URL > HTTPS_PROXY/HTTP_PROXY > direct connection
-const MAL_SOCKS_PROXY_URL = process.env.MAL_SOCKS_PROXY_URL;
-const HTTP_PROXY_URL = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-let malDispatcher;
-
-if (MAL_SOCKS_PROXY_URL) {
-  try {
-    const proxyUrlObj = new URL(MAL_SOCKS_PROXY_URL);
-    if (proxyUrlObj.protocol === 'socks5:' || proxyUrlObj.protocol === 'socks4:') {
-      malDispatcher = socksDispatcher({
-        type: proxyUrlObj.protocol === 'socks5:' ? 5 : 4,
-        host: proxyUrlObj.hostname,
-        port: parseInt(proxyUrlObj.port),
-        userId: proxyUrlObj.username,
-        password: proxyUrlObj.password,
-      });
-      logger.info(`SOCKS proxy is enabled for Jikan API via fetch-socks.`);
-    } else {
-      logger.warn(`Unsupported proxy protocol: ${proxyUrlObj.protocol}. Falling back.`);
-      malDispatcher = null; // Will be set below
-    }
-  } catch (error) {
-    logger.warn(`Invalid MAL_SOCKS_PROXY_URL. Falling back. Error: ${error.message}`);
-    malDispatcher = null; // Will be set below
-  }
-}
-
-// Fallback to HTTP proxy or direct connection
-if (!malDispatcher) {
-  if (HTTP_PROXY_URL) {
-    try {
-      malDispatcher = new ProxyAgent({ uri: new URL(HTTP_PROXY_URL).toString(), allowH2: false });
-      logger.info('Using global HTTP proxy for Jikan API.');
-    } catch (error) {
-      logger.warn(`Invalid HTTP_PROXY URL. Using direct connection. Error: ${error.message}`);
-      malDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
-    }
-  } else {
-    malDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
-    logger.info('undici agent is enabled for direct connections.');
-  }
-}
+// MAL/Jikan dispatcher
+// priority: MAL_SOCKS_PROXY_URL > HTTPS_PROXY/HTTP_PROXY > direct
+const malDispatcher = createDispatcher({
+  label: 'MAL',
+  socksProxyEnvVar: 'MAL_SOCKS_PROXY_URL',
+  agentOptions: { connect: { timeout: 30_000 } },
+});
 
 // --- Rate limit configuration ---
 // Jikan limits: 3 requests/second, 60 requests/minute

--- a/addon/lib/tvmaze.ts
+++ b/addon/lib/tvmaze.ts
@@ -1,7 +1,6 @@
-import { httpGet } from '../utils/httpClient.js';
+import { httpGet, createDispatcher } from '../utils/httpClient.js';
 import { cacheWrapTvmazeApi } from './getCache.js';
 const buildInfo = require('./buildInfo');
-import { Agent, ProxyAgent } from 'undici';
 const TVMAZE_API_URL = 'https://api.tvmaze.com';
 const DEFAULT_TIMEOUT = 15000; // 15-second timeout for all requests
 const MAX_RETRIES = 3;
@@ -9,31 +8,11 @@ const RETRY_DELAY = 1000; // 1 second base delay for network errors
 const RATE_LIMIT_FALLBACK_DELAY = 10000; // 10 seconds fallback if Retry-After header is missing
 const RETRY_AFTER_BUFFER = 1000; // Add 1 second buffer to Retry-After value
 
-// TVmaze dispatcher configuration
-// Priority: HTTPS_PROXY/HTTP_PROXY > direct connection
-const HTTP_PROXY_URL = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-let tvmazeAgent: Agent | ProxyAgent;
-
-if (HTTP_PROXY_URL) {
-  try {
-    tvmazeAgent = new ProxyAgent({ uri: new URL(HTTP_PROXY_URL).toString(), allowH2: false });
-    console.log('[TVmaze] Using global HTTP proxy.');
-  } catch (error: any) {
-    console.error(`[TVmaze] Invalid HTTP_PROXY URL. Using direct connection. Error: ${error.message}`);
-    tvmazeAgent = new Agent({
-      allowH2: false,
-      connections: 2,
-      keepAliveTimeout: 10 * 1000,
-    });
-  }
-} else {
-  tvmazeAgent = new Agent({
-    allowH2: false,
-    connections: 2,
-    keepAliveTimeout: 10 * 1000,
-  });
-  console.log('[TVmaze] undici agent is enabled for direct connections (2 max connections to avoid IP blocking).');
-}
+// TVmaze dispatcher
+const tvmazeAgent = createDispatcher({
+  label: 'TVmaze',
+  agentOptions: { connections: 2, keepAliveTimeout: 10_000 },
+});
 
 // Default HTTP client config with User-Agent as recommended by TVmaze
 const DEFAULT_HTTP_CONFIG = {

--- a/addon/utils/gemini-client.js
+++ b/addon/utils/gemini-client.js
@@ -1,51 +1,20 @@
-const { request, Agent, ProxyAgent } = require('undici');
+const { request } = require('undici');
+const { createDispatcher } = require('./httpClient.js');
 
 const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 
-// Gemini dispatcher configuration
-// Priority: GEMINI_HTTPS_PROXY/GEMINI_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct connection
-const getGeminiProxyUrl = () => {
-  // First check for Gemini-specific proxy
-  const geminiProxy = process.env.GEMINI_HTTPS_PROXY ?? process.env.GEMINI_HTTP_PROXY;
-  if (geminiProxy) {
-    try {
-      return new URL(geminiProxy).toString();
-    } catch (error) {
-      console.warn('Invalid Gemini proxy URL:', geminiProxy);
-    }
-  }
-  // Fall back to global proxy
-  const globalProxy = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-  if (globalProxy) {
-    try {
-      return new URL(globalProxy).toString();
-    } catch (error) {
-      console.warn('Invalid global proxy URL:', globalProxy);
-    }
-  }
-  return null;
-};
-
-// Create Gemini dispatcher
-// Uses Gemini-specific proxy if set, otherwise global proxy, otherwise direct connection
-const createGeminiDispatcher = () => {
-  const proxyUrl = getGeminiProxyUrl();
-  if (proxyUrl) {
-    return new ProxyAgent({ uri: proxyUrl, allowH2: false });
-  }
-  // No proxy configured - use direct connection
-  return new Agent({
-    allowH2: false,
-    keepAliveTimeout: 30000,      // Keep connections alive for 30s
-    keepAliveMaxTimeout: 60000,   // Max keep-alive time 60s
-    connections: 50,              // Max concurrent connections
-    pipelining: 1,                // HTTP/1.1 pipelining
-  });
-};
-
-// Shared dispatcher for all requests to Gemini API
-// This is always a dedicated Agent/ProxyAgent, never using the global dispatcher
-const geminiDispatcher = createGeminiDispatcher();
+// Gemini dispatcher
+// priority: GEMINI_HTTPS_PROXY/GEMINI_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct
+const geminiDispatcher = createDispatcher({
+  label: 'Gemini',
+  proxyEnvVars: ['GEMINI_HTTPS_PROXY', 'GEMINI_HTTP_PROXY', 'HTTPS_PROXY', 'HTTP_PROXY'],
+  agentOptions: {
+    keepAliveTimeout: 30_000,
+    keepAliveMaxTimeout: 60_000,
+    connections: 50,
+    pipelining: 1,
+  },
+});
 
 /**
  * Generate content using Gemini API with optional Google Search grounding.

--- a/addon/utils/httpClient.js
+++ b/addon/utils/httpClient.js
@@ -1,31 +1,93 @@
 const { request, setGlobalDispatcher, ProxyAgent, Agent, interceptors } = require("undici");
 const buildInfo = require('../lib/buildInfo');
 
-// Global proxy configuration - applies to all undici requests
-// Prefers HTTPS_PROXY since most API calls are HTTPS, falls back to HTTP_PROXY
-const getProxyUrl = () => {
-  const proxy = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-  if (proxy) {
-    try {
-      return new URL(proxy).toString();
-    } catch (error) {
-      console.warn('Invalid proxy URL in HTTP_PROXY/HTTPS_PROXY:', proxy);
-      return null;
+// Shared DNS interceptor, caches lookups up to their TTL (max 60s).
+// Applied to every dispatcher created by createDispatcher() and to the global dispatcher.
+const dnsInterceptor = interceptors.dns({ maxTTL: 60_000 });
+
+/**
+ * Creates an undici Dispatcher with DNS caching and optional proxy support.
+ *
+ * Priority when resolving the proxy:
+ *   1. SOCKS proxy (socksProxyEnvVar)
+ *   2. HTTP/HTTPS proxy (proxyEnvVars, checked left-to-right)
+ *   3. Direct connection
+ *
+ * @param {object} [options={}]
+ * @param {string[]} [options.proxyEnvVars=['HTTPS_PROXY','HTTP_PROXY']]
+ *   Env-var names to check for an HTTP/HTTPS proxy URL, in priority order.
+ *   Pass [] to skip proxy lookup and always use a direct connection.
+ * @param {string}  [options.socksProxyEnvVar]
+ *   Env-var name for a SOCKS4/5 proxy URL (requires the `fetch-socks` package).
+ *   Checked before proxyEnvVars.
+ * @param {object}  [options.agentOptions={}]
+ *   Extra options forwarded to `new Agent()` for direct connections
+ *   (e.g. { connections: 2, keepAliveTimeout: 10_000 }).
+ * @param {object}  [options.proxyOptions={}]
+ *   Extra options forwarded to `new ProxyAgent()` when a proxy is used
+ *   (e.g. { requestTls: { timeout: 30_000 } }).
+ * @param {string}  [options.label]
+ *   Service name used in log output (e.g. 'TVmaze').
+ * @returns {import('undici').Dispatcher} Dispatcher with DNS caching applied.
+ */
+function createDispatcher({
+  proxyEnvVars = ['HTTPS_PROXY', 'HTTP_PROXY'],
+  socksProxyEnvVar,
+  agentOptions = {},
+  proxyOptions = {},
+  label,
+} = {}) {
+  const tag = label ? `[${label}]` : '[HTTP]';
+
+  // 1. SOCKS proxy
+  if (socksProxyEnvVar) {
+    const socksUrl = process.env[socksProxyEnvVar];
+    if (socksUrl) {
+      try {
+        const proxyUrlObj = new URL(socksUrl);
+        if (proxyUrlObj.protocol === 'socks5:' || proxyUrlObj.protocol === 'socks4:') {
+          const { socksDispatcher } = require('fetch-socks');
+          const d = socksDispatcher({
+            type: proxyUrlObj.protocol === 'socks5:' ? 5 : 4,
+            host: proxyUrlObj.hostname,
+            port: parseInt(proxyUrlObj.port),
+            userId: proxyUrlObj.username,
+            password: proxyUrlObj.password,
+          });
+          console.log(`${tag} SOCKS proxy enabled (${socksProxyEnvVar}).`);
+          return d.compose(dnsInterceptor);
+        } else {
+          console.warn(`${tag} Unsupported SOCKS protocol: ${proxyUrlObj.protocol}. Falling back.`);
+        }
+      } catch (error) {
+        console.warn(`${tag} Invalid ${socksProxyEnvVar}. Falling back. Error: ${error.message}`);
+      }
     }
   }
-  return null;
-};
 
-const proxyUrl = getProxyUrl();
-const baseDispatcher = proxyUrl
-  ? new ProxyAgent({ uri: proxyUrl, allowH2: false })
-  : new Agent();
+  // 2. HTTP/HTTPS proxy, try each env var in order
+  for (const envVar of proxyEnvVars) {
+    const proxyUrl = process.env[envVar];
+    if (!proxyUrl) continue;
+    try {
+      const d = new ProxyAgent({ uri: new URL(proxyUrl).toString(), allowH2: false, ...proxyOptions });
+      console.log(`${tag} Using proxy from ${envVar}.`);
+      return d.compose(dnsInterceptor);
+    } catch (error) {
+      console.warn(`${tag} Invalid proxy URL in ${envVar}. Falling back. Error: ${error.message}`);
+    }
+  }
 
-const dispatcher = baseDispatcher.compose(
-  interceptors.dns({ maxTTL: 60_000 })
-);
+  // 3. Direct connection
+  const d = new Agent({ ...agentOptions });
+  if (label) console.log(`${tag} Direct connection.`);
+  return d.compose(dnsInterceptor);
+}
 
-setGlobalDispatcher(dispatcher);
+// Global dispatcher, all httpGet/httpPost/httpRequest calls use this unless
+// a per-call dispatcher is passed explicitly.
+const globalDispatcher = createDispatcher({ label: 'Global' });
+setGlobalDispatcher(globalDispatcher);
 
 /**
  * HTTP client wrapper optimized for MAXIMUM SPEED.
@@ -185,5 +247,6 @@ module.exports = {
   httpRequest,
   httpGet,
   httpPost,
-  httpHead
+  httpHead,
+  createDispatcher,
 };

--- a/addon/utils/httpClient.js
+++ b/addon/utils/httpClient.js
@@ -1,9 +1,10 @@
 const { request, setGlobalDispatcher, ProxyAgent, Agent, interceptors } = require("undici");
 const buildInfo = require('../lib/buildInfo');
 
-// Shared DNS interceptor, caches lookups up to their TTL (max 60s).
-// Applied to every dispatcher created by createDispatcher() and to the global dispatcher.
-const dnsInterceptor = interceptors.dns({ maxTTL: 60_000 });
+// Create a fresh DNS interceptor per direct dispatcher.
+function createDnsInterceptor() {
+  return interceptors.dns({ maxTTL: 60_000 });
+}
 
 /**
  * Creates an undici Dispatcher with DNS caching and optional proxy support.
@@ -28,7 +29,8 @@ const dnsInterceptor = interceptors.dns({ maxTTL: 60_000 });
  *   (e.g. { requestTls: { timeout: 30_000 } }).
  * @param {string}  [options.label]
  *   Service name used in log output (e.g. 'TVmaze').
- * @returns {import('undici').Dispatcher} Dispatcher with DNS caching applied.
+ * @returns {import('undici').Dispatcher}
+ *   Dispatcher with DNS caching applied.
  */
 function createDispatcher({
   proxyEnvVars = ['HTTPS_PROXY', 'HTTP_PROXY'],
@@ -50,12 +52,12 @@ function createDispatcher({
           const d = socksDispatcher({
             type: proxyUrlObj.protocol === 'socks5:' ? 5 : 4,
             host: proxyUrlObj.hostname,
-            port: parseInt(proxyUrlObj.port),
+            port: Number(proxyUrlObj.port),
             userId: proxyUrlObj.username,
             password: proxyUrlObj.password,
           });
           console.log(`${tag} SOCKS proxy enabled (${socksProxyEnvVar}).`);
-          return d.compose(dnsInterceptor);
+          return d.compose(createDnsInterceptor());
         } else {
           console.warn(`${tag} Unsupported SOCKS protocol: ${proxyUrlObj.protocol}. Falling back.`);
         }
@@ -72,7 +74,7 @@ function createDispatcher({
     try {
       const d = new ProxyAgent({ uri: new URL(proxyUrl).toString(), allowH2: false, ...proxyOptions });
       console.log(`${tag} Using proxy from ${envVar}.`);
-      return d.compose(dnsInterceptor);
+      return d.compose(createDnsInterceptor());
     } catch (error) {
       console.warn(`${tag} Invalid proxy URL in ${envVar}. Falling back. Error: ${error.message}`);
     }
@@ -81,7 +83,7 @@ function createDispatcher({
   // 3. Direct connection
   const d = new Agent({ ...agentOptions });
   if (label) console.log(`${tag} Direct connection.`);
-  return d.compose(dnsInterceptor);
+  return d.compose(createDnsInterceptor());
 }
 
 // Global dispatcher, all httpGet/httpPost/httpRequest calls use this unless

--- a/addon/utils/httpClient.js
+++ b/addon/utils/httpClient.js
@@ -1,4 +1,4 @@
-const { request, setGlobalDispatcher, ProxyAgent } = require("undici");
+const { request, setGlobalDispatcher, ProxyAgent, Agent, interceptors } = require("undici");
 const buildInfo = require('../lib/buildInfo');
 
 // Global proxy configuration - applies to all undici requests
@@ -17,10 +17,15 @@ const getProxyUrl = () => {
 };
 
 const proxyUrl = getProxyUrl();
-if (proxyUrl) {
-  const dispatcher = new ProxyAgent({ uri: proxyUrl, allowH2: false });
-  setGlobalDispatcher(dispatcher);
-}
+const baseDispatcher = proxyUrl
+  ? new ProxyAgent({ uri: proxyUrl, allowH2: false })
+  : new Agent();
+
+const dispatcher = baseDispatcher.compose(
+  interceptors.dns({ maxTTL: 60_000 })
+);
+
+setGlobalDispatcher(dispatcher);
 
 /**
  * HTTP client wrapper optimized for MAXIMUM SPEED.

--- a/addon/utils/letterboxdUtils.ts
+++ b/addon/utils/letterboxdUtils.ts
@@ -1,15 +1,18 @@
 
-import { httpGet, httpHead } from "./httpClient.js";
+import { httpGet, httpHead, createDispatcher } from "./httpClient.js";
 import { cacheWrapMetaSmart } from "../lib/getCache.js";
 import { getMeta } from "../lib/getMeta.js";
 import { UserConfig } from "../types/index.js";
 const consola = require('consola');
-const { Agent } = require('undici');
 const buildInfo = require('../lib/buildInfo');
 
 const logger = consola.withTag('Letterboxd');
 
-const letterboxdDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
+const letterboxdDispatcher = createDispatcher({
+  label: 'Letterboxd',
+  proxyEnvVars: [],
+  agentOptions: { connect: { timeout: 30_000 } },
+});
 
 // Rate limiting configuration for Letterboxd API (through StremThru)
 const RATE_LIMIT_CONFIG = {

--- a/addon/utils/mdbList.ts
+++ b/addon/utils/mdbList.ts
@@ -1,4 +1,4 @@
-import { httpGet, httpPost } from "./httpClient.js";
+import { httpGet, httpPost, createDispatcher } from "./httpClient.js";
 import { resolveAllIds } from "../lib/id-resolver.js";
 const buildInfo = require('../lib/buildInfo');
 import { getMeta } from "../lib/getMeta.js";
@@ -6,8 +6,6 @@ import { cacheWrapMetaSmart, cacheWrapMDBListGenres, cacheWrapGlobal } from "../
 import { UserConfig } from "../types/index.js";
 const consola = require('consola');
 const crypto = require('crypto');
-const { socksDispatcher } = require('fetch-socks');
-const { Agent, ProxyAgent } = require('undici');
 
 const logger = consola.withTag('MDBList');
 
@@ -22,51 +20,13 @@ function sanitizeUrlForLogging(url: string): string {
 }
 
 
-// MDBList dispatcher configuration
-// Priority: MDBLIST_SOCKS_PROXY_URL > HTTPS_PROXY/HTTP_PROXY > direct connection
-const MDBLIST_SOCKS_PROXY_URL = process.env.MDBLIST_SOCKS_PROXY_URL;
-const HTTP_PROXY_URL = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-let mdblistDispatcher: any;
-
-if (MDBLIST_SOCKS_PROXY_URL) {
-  try {
-    const proxyUrlObj = new URL(MDBLIST_SOCKS_PROXY_URL);
-    if (proxyUrlObj.protocol === 'socks5:' || proxyUrlObj.protocol === 'socks4:') {
-      mdblistDispatcher = socksDispatcher({
-        type: proxyUrlObj.protocol === 'socks5:' ? 5 : 4,
-        host: proxyUrlObj.hostname,
-        port: parseInt(proxyUrlObj.port),
-        userId: proxyUrlObj.username,
-        password: proxyUrlObj.password,
-      });
-      logger.info(`[MDBList] SOCKS proxy is enabled for MDBList API via fetch-socks.`);
-    } else {
-      logger.error(`[MDBList] Unsupported proxy protocol: ${proxyUrlObj.protocol}. Falling back.`);
-      mdblistDispatcher = null; // Will be set below
-    }
-  } catch (error: any) {
-    logger.error(`[MDBList] Invalid MDBLIST_SOCKS_PROXY_URL. Falling back. Error: ${error.message}`);
-    mdblistDispatcher = null; // Will be set below
-  }
-}
-
-// Fallback to HTTP proxy or direct connection
-if (!mdblistDispatcher) {
-  if (HTTP_PROXY_URL) {
-    try {
-      // ProxyAgent may need to be imported if not already
-      const { ProxyAgent } = require('undici');
-      mdblistDispatcher = new ProxyAgent({ uri: new URL(HTTP_PROXY_URL).toString(), allowH2: false });
-      logger.info('[MDBList] Using global HTTP proxy.');
-    } catch (error: any) {
-      logger.error(`[MDBList] Invalid HTTP_PROXY URL. Using direct connection. Error: ${error.message}`);
-      mdblistDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
-    }
-  } else {
-    mdblistDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
-    logger.info('[MDBList] undici agent is enabled for direct connections.');
-  }
-}
+// MDBList dispatcher
+// priority: MDBLIST_SOCKS_PROXY_URL > HTTPS_PROXY/HTTP_PROXY > direct
+const mdblistDispatcher = createDispatcher({
+  label: 'MDBList',
+  socksProxyEnvVar: 'MDBLIST_SOCKS_PROXY_URL',
+  agentOptions: { connect: { timeout: 30_000 } },
+});
 
 /**
  * Checks if an error is a "permanent" client-side error that should not be retried.

--- a/addon/utils/openrouter-client.js
+++ b/addon/utils/openrouter-client.js
@@ -1,44 +1,20 @@
-const { request, Agent, ProxyAgent } = require('undici');
+const { request } = require('undici');
+const { createDispatcher } = require('./httpClient.js');
 
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
-// OpenRouter dispatcher configuration
-// Priority: OPENROUTER_HTTPS_PROXY/OPENROUTER_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct connection
-const getOpenRouterProxyUrl = () => {
-  const orProxy = process.env.OPENROUTER_HTTPS_PROXY ?? process.env.OPENROUTER_HTTP_PROXY;
-  if (orProxy) {
-    try {
-      return new URL(orProxy).toString();
-    } catch (error) {
-      console.warn('Invalid OpenRouter proxy URL:', orProxy);
-    }
-  }
-  const globalProxy = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-  if (globalProxy) {
-    try {
-      return new URL(globalProxy).toString();
-    } catch (error) {
-      console.warn('Invalid global proxy URL:', globalProxy);
-    }
-  }
-  return null;
-};
-
-const createOpenRouterDispatcher = () => {
-  const proxyUrl = getOpenRouterProxyUrl();
-  if (proxyUrl) {
-    return new ProxyAgent({ uri: proxyUrl, allowH2: false });
-  }
-  return new Agent({
-    allowH2: false,
-    keepAliveTimeout: 30000,
-    keepAliveMaxTimeout: 60000,
+// OpenRouter dispatcher
+// priority: OPENROUTER_HTTPS_PROXY/OPENROUTER_HTTP_PROXY > HTTPS_PROXY/HTTP_PROXY > direct
+const openrouterDispatcher = createDispatcher({
+  label: 'OpenRouter',
+  proxyEnvVars: ['OPENROUTER_HTTPS_PROXY', 'OPENROUTER_HTTP_PROXY', 'HTTPS_PROXY', 'HTTP_PROXY'],
+  agentOptions: {
+    keepAliveTimeout: 30_000,
+    keepAliveMaxTimeout: 60_000,
     connections: 50,
     pipelining: 1,
-  });
-};
-
-const openrouterDispatcher = createOpenRouterDispatcher();
+  },
+});
 
 /**
  * Generate content using OpenRouter API (OpenAI-compatible).

--- a/addon/utils/simklUtils.ts
+++ b/addon/utils/simklUtils.ts
@@ -1,11 +1,10 @@
-import { httpGet, httpPost } from "./httpClient.js";
+import { httpGet, httpPost, createDispatcher } from "./httpClient.js";
 import { getMeta } from "../lib/getMeta.js";
 import { cacheWrapMetaSmart, cacheWrapGlobal } from "../lib/getCache.js";
 import { UserConfig } from "../types/index.js";
 import * as Utils from "./parseProps.js";
 import { progress } from "framer-motion";
 const consola = require('consola');
-const { Agent } = require('undici');
 const crypto = require('crypto');
 const database = require('../lib/database.js');
 const requestTracker = require('../lib/requestTracker.js');
@@ -28,7 +27,10 @@ function sanitizeUrlForLogging(url: string): string {
   return url.replace(/(Authorization: Bearer\s+)[^\s]+/gi, '$1[REDACTED]');
 }
 
-const simklDispatcher = new Agent({ allowH2: false, connect: { timeout: 30000 } });
+const simklDispatcher = createDispatcher({
+  label: 'Simkl',
+  agentOptions: { connect: { timeout: 30_000 } },
+});
 
 /**
  * Checks if an error is a "permanent" client-side error that should not be retried.

--- a/addon/utils/traktUtils.ts
+++ b/addon/utils/traktUtils.ts
@@ -1,10 +1,9 @@
-import { httpGet, httpPost } from "./httpClient.js";
+import { httpGet, httpPost, createDispatcher } from "./httpClient.js";
 import { getMeta } from "../lib/getMeta.js";
 import { cacheWrapMetaSmart, cacheWrapGlobal } from "../lib/getCache.js";
 import { UserConfig } from "../types/index.js";
 const consola = require('consola');
 const crypto = require('crypto');
-import {Agent, ProxyAgent } from 'undici';
 const database = require('../lib/database.js');
 const redis = require('../lib/redisClient');
 
@@ -29,10 +28,12 @@ function sanitizeUrlForLogging(url: string): string {
   return url.replace(/(Authorization: Bearer\s+)[^\s]+/gi, '$1[REDACTED]');
 }
 
-const TRAKT_PROXY_URL = process.env.TRAKT_PROXY_URL;
-const traktDispatcher = TRAKT_PROXY_URL 
-  ? new ProxyAgent({ uri: TRAKT_PROXY_URL, allowH2: false, requestTls: { timeout: 30000 } })
-  : new Agent({ allowH2: false, connect: { timeout: 30000 } });
+const traktDispatcher = createDispatcher({
+  label: 'Trakt',
+  proxyEnvVars: ['TRAKT_PROXY_URL'],
+  agentOptions: { connect: { timeout: 30_000 } },
+  proxyOptions: { requestTls: { timeout: 30_000 } },
+});
 
 
 /**


### PR DESCRIPTION
## Problem

AIOMetadata performs a (very) large number of repeated upstream DNS lookups during normal use.

## Solution

Install a shared undici dispatcher for each client and enable undici’s built in [DNS cache](https://github.com/nodejs/undici/blob/main/docs/docs/api/Dispatcher.md#dns) with a 60s max TTL.

In practice this should reduce repeated upstream DNS lookups and improve connection reuse by keeping requests on a single configured dispatcher.

## Note

undici's docs mention setting [connections](https://github.com/nodejs/undici/blob/main/docs/examples/README.md#using-interceptors-to-add-response-caching-dns-lookup-caching-and-connection-retries) (see [PoolOptions](https://github.com/nodejs/undici/blob/main/docs/docs/api/Pool.md#parameter-pooloptions)) to something reasonable in order to limit the number of concurrent connections per origin. Some existing clients specify this already while others don't.

Additionally, given the scale of outbound requests this addon makes, the [cache](https://github.com/nodejs/undici/blob/main/docs/docs/api/Dispatcher.md#cache-interceptor) and [deduplicate](https://github.com/nodejs/undici/blob/main/docs/docs/api/Dispatcher.md#deduplicate-interceptor) interceptors are worth considering separately.