### PR TITLE
fix: allow duplicate Letterboxd list catalogs

### DIFF
--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2224,16 +2224,14 @@ async function getLetterboxdCatalog(
   includeVideos: boolean = false
 ): Promise<any[]> {
   try {
-    // Extract identifier from catalog ID (format: letterboxd.<identifier>)
-    const identifier = catalogId.replace('letterboxd.', '');
-    
+    // Find catalog config to determine source identifier and watchlist flag
+    const catalogConfig = config.catalogs?.find(c => c.id === catalogId);
+    // Prefer metadata identifier to support duplicated catalogs with suffixed IDs.
+    const identifier = catalogConfig?.metadata?.identifier || catalogId.replace('letterboxd.', '');
     if (!identifier) {
       logger.error(`Invalid Letterboxd catalog ID: ${catalogId}`);
       return [];
     }
-
-    // Find catalog config to determine if it's a watchlist
-    const catalogConfig = config.catalogs?.find(c => c.id === catalogId);
     const isWatchlist = catalogConfig?.metadata?.isWatchlist || false;
 
     logger.info(`Fetching Letterboxd ${isWatchlist ? 'watchlist' : 'list'}: ${identifier}, Page: ${page}`);

--- a/configure/src/components/QuickAddDialog.tsx
+++ b/configure/src/components/QuickAddDialog.tsx
@@ -534,13 +534,6 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
       }
 
       const { identifier, isWatchlist } = await extractResponse.json();
-      const catalogId = `letterboxd.${identifier}`;
-
-      if (catalogExists(catalogId)) {
-        toast.info("This Letterboxd list is already in your catalogs");
-        onClose();
-        return;
-      }
 
       // Fetch list metadata from StremThru
       const listResponse = await fetch('/api/letterboxd/list', {
@@ -566,6 +559,7 @@ export function QuickAddDialog({ isOpen, onClose }: QuickAddDialogProps) {
         url: parsedUrl.url,
         cacheTTL: catalogTTL,
         displayTypeOverrides: config.displayTypeOverrides,
+        existingCatalogs: config.catalogs,
       });
 
       setConfig(prev => ({

--- a/configure/src/components/sections/LetterboxdIntegration.tsx
+++ b/configure/src/components/sections/LetterboxdIntegration.tsx
@@ -94,17 +94,6 @@ export function LetterboxdIntegration({ isOpen, onClose }: LetterboxdIntegration
       const itemCount = listData.data?.items?.length || 0;
 
       // Step 3: Create catalog
-      const catalogId = `letterboxd.${identifier}`;
-
-      // Check if catalog already exists
-      if (config.catalogs.some(c => c.id === catalogId)) {
-        toast.error("List already added", {
-          description: "This Letterboxd list is already in your catalogs"
-        });
-        setIsProcessing(false);
-        return;
-      }
-
       const newCatalog = createLetterboxdCatalog({
         identifier,
         title: listTitle,
@@ -113,6 +102,7 @@ export function LetterboxdIntegration({ isOpen, onClose }: LetterboxdIntegration
         url: listUrl,
         cacheTTL: defaultCacheTTL,
         displayTypeOverrides: config.displayTypeOverrides,
+        existingCatalogs: config.catalogs,
       });
 
       setConfig(prev => ({

--- a/configure/src/utils/catalogUtils.ts
+++ b/configure/src/utils/catalogUtils.ts
@@ -260,6 +260,7 @@ export interface LetterboxdCatalogOptions {
   url: string;
   cacheTTL?: number;
   displayTypeOverrides?: { movie?: string; series?: string };
+  existingCatalogs?: CatalogConfig[];
 }
 
 /**
@@ -276,12 +277,20 @@ export function createLetterboxdCatalog(options: LetterboxdCatalogOptions): Cata
     url,
     cacheTTL = 86400, // Default 24 hours
     displayTypeOverrides,
+    existingCatalogs = [],
   } = options;
 
   const displayType = getDisplayTypeOverride('movie', displayTypeOverrides);
+  const sameIdentifierCount = existingCatalogs.filter((catalog) => {
+    if (catalog.source !== 'letterboxd') return false;
+    return catalog.metadata?.identifier === identifier;
+  }).length;
+  const catalogId = sameIdentifierCount === 0
+    ? `letterboxd.${identifier}`
+    : `letterboxd.${identifier}.${sameIdentifierCount + 1}`;
 
   return {
-    id: `letterboxd.${identifier}`,
+    id: catalogId,
     type: 'movie', // Letterboxd is primarily movies
     name: title,
     enabled: true,


### PR DESCRIPTION
## Summary
- allow importing the same Letterboxd list multiple times by generating unique catalog IDs
- remove duplicate-import guard in Letterboxd integration and quick add
- resolve Letterboxd identifier from catalog metadata so duplicate IDs still fetch the correct list

## Test plan
- add a Letterboxd list once and confirm it imports
- add the same list again and confirm a second catalog is created
- set one catalog variant to randomized order and keep the other in original order
- verify both catalogs load successfully