### PR TITLE
fix(custom-art): normalize encoded placeholders at config boundaries

### DIFF
--- a/addon/lib/database.js
+++ b/addon/lib/database.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const bcrypt = require('bcrypt');
 const redisIdCache = require('./redis-id-cache');
+const { normalizeCustomArtPatternsInConfig } = require('../utils/parseProps');
 const consola = require('consola');
 const logger = consola.withTag('Database');
 
@@ -283,6 +284,7 @@ class Database {
 
     let configJson;
     if (normalizedConfig && typeof normalizedConfig === 'object' && !Array.isArray(normalizedConfig)) {
+      normalizedConfig = normalizeCustomArtPatternsInConfig(normalizedConfig);
       const configForHash = { ...normalizedConfig };
       delete configForHash.configHash;
       const configHash = crypto.createHash('md5').update(JSON.stringify(configForHash)).digest('hex').substring(0, 16);
@@ -335,9 +337,11 @@ class Database {
     if (!row) return null;
     
     try {
-      return typeof row.config_data === 'string' 
-        ? JSON.parse(row.config_data) 
+      const config = typeof row.config_data === 'string'
+        ? JSON.parse(row.config_data)
         : row.config_data;
+
+      return normalizeCustomArtPatternsInConfig(config);
     } catch (error) {
       logger.error('Error parsing config data:', error);
       return null;

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -28,6 +28,47 @@ const logger = consola.withTag('ParseProps');
 // Check if debug is enabled (CONSOLA_LEVEL >= 4)
 const isDebugEnabled = consola.level >= 4;
 
+const CUSTOM_ART_PATTERN_KEYS = [
+  'customPosterUrlPattern',
+  'customBackgroundUrlPattern',
+  'customLogoUrlPattern',
+  'customThumbnailUrlPattern',
+];
+
+function normalizeEncodedCustomArtPattern(pattern) {
+  if (typeof pattern !== 'string' || !pattern.includes('%7B')) return pattern;
+
+  return pattern.replace(/%7B[a-z0-9_]+%7D/gi, (match) => {
+    try {
+      return decodeURIComponent(match);
+    } catch {
+      return match;
+    }
+  });
+}
+
+function normalizeCustomArtPatternsInConfig(config) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return config;
+  }
+
+  let nextConfig = config;
+
+  for (const key of CUSTOM_ART_PATTERN_KEYS) {
+    const currentValue = nextConfig[key];
+    const normalizedValue = normalizeEncodedCustomArtPattern(currentValue);
+
+    if (normalizedValue !== currentValue) {
+      if (nextConfig === config) {
+        nextConfig = { ...config };
+      }
+      nextConfig[key] = normalizedValue;
+    }
+  }
+
+  return nextConfig;
+}
+
 /**
  * Helper function to check if RPDB is enabled for the current context
  * Checks per-catalog settings if available, otherwise defaults to true
@@ -3441,7 +3482,8 @@ module.exports = {
   getTvdbCertification,
   getAnimePosterUrl,
   getKitsuLocalizedTitle,
-  resolveCustomArtUrl
+  resolveCustomArtUrl,
+  normalizeCustomArtPatternsInConfig
 };
 
 /**


### PR DESCRIPTION
## Summary

Normalize encoded custom art placeholders when config is saved and loaded, so custom poster, background, logo, and thumbnail patterns are already in a resolvable form before request-time art resolution runs.

## Why

Some saved custom art patterns contain percent-encoded placeholders like `%7Bimdb_id%7D`, `%7Bseason%7D`, and `%7Bepisode%7D`.

Without normalization, those values can pass through unchanged and downstream consumers receive literal placeholder tokens instead of resolved artwork URLs.

## What changed

- normalize placeholder-shaped `%7B...%7D` tokens on custom art pattern fields at config save/load time
- remove the runtime placeholder rewrite path from `resolveCustomArtUrl`
- keep request-time resolution focused on substituting already-normalized patterns

## Validation

- `node --check addon/utils/parseProps.js`
- `node --check addon/lib/database.js`

## Notes

This keeps the fix at the config boundary instead of maintaining a second placeholder list inside the runtime resolver.
