### PR TITLE
Add optional MAX_CATALOGS cap on user configs

### DIFF
--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -129,6 +129,28 @@ class ConfigApi {
     return { valid: true };
   }
 
+  // Optional cap on catalog count per user. Opt-in via MAX_CATALOGS env var.
+  // Leaving MAX_CATALOGS unset (the default) preserves the previous unbounded
+  // behaviour — nothing is enforced. When set to a positive integer, saves
+  // with more than N catalogs are rejected. Some users have accumulated 800+
+  // catalogs in the past; every manifest request iterates the full array, so
+  // outliers cost 10× the baseline CPU/RAM per request.
+  validateCatalogCount(config) {
+    const raw = process.env.MAX_CATALOGS;
+    if (!raw) return { valid: true };
+    const max = Number.parseInt(raw, 10);
+    if (!Number.isFinite(max) || max <= 0) return { valid: true };
+    const catalogs = config && config.catalogs;
+    if (!Array.isArray(catalogs)) return { valid: true };
+    if (catalogs.length <= max) return { valid: true };
+    return {
+      valid: false,
+      count: catalogs.length,
+      max,
+      message: `Too many catalogs (${catalogs.length}); the maximum allowed on this instance is ${max}. Remove some catalogs and try again.`,
+    };
+  }
+
   // Save configuration with password
   async saveConfig(req, res) {
     logger.debug('saveConfig called - starting function');
@@ -160,9 +182,19 @@ class ConfigApi {
       // Validate required API keys
       const validation = this.validateRequiredKeys(config);
       if (!validation.valid) {
-        return res.status(400).json({ 
+        return res.status(400).json({
           error: validation.message,
           missingKeys: validation.missingKeys
+        });
+      }
+
+      // Optional catalog count ceiling (opt-in via MAX_CATALOGS env var)
+      const catalogCheck = this.validateCatalogCount(config);
+      if (!catalogCheck.valid) {
+        return res.status(400).json({
+          error: catalogCheck.message,
+          catalogCount: catalogCheck.count,
+          maxCatalogs: catalogCheck.max,
         });
       }
 
@@ -483,12 +515,22 @@ class ConfigApi {
       // Validate required API keys
       const validation = this.validateRequiredKeys(config);
       if (!validation.valid) {
-        return res.status(400).json({ 
+        return res.status(400).json({
           error: validation.message,
           missingKeys: validation.missingKeys
         });
       }
-      
+
+      // Optional catalog count ceiling (opt-in via MAX_CATALOGS env var)
+      const catalogCheck = this.validateCatalogCount(config);
+      if (!catalogCheck.valid) {
+        return res.status(400).json({
+          error: catalogCheck.message,
+          catalogCount: catalogCheck.count,
+          maxCatalogs: catalogCheck.max,
+        });
+      }
+
       await this.sanitizeTraktToken(config);
 
       // Verify existing config exists


### PR DESCRIPTION
## Summary

Adds an opt-in ceiling on the number of catalogs per user config, gated by the new `MAX_CATALOGS` env var. When unset (default), existing behaviour is preserved.

## Motivation

A production dataset shows a small tail of users with extreme catalog counts — mean ~78, max **845**. Every manifest request for those users iterates the full `catalogs` array, so a single outlier costs roughly 10× the baseline CPU and memory of a normal request. Stremio's UI doesn't display more than a few dozen catalogs usefully anyway, so the tail of the distribution is mostly noise that still has to be parsed, mapped, deduped, and serialized.

Giving operators the option to cap this protects shared resources on public instances without affecting self-hosters (who can leave it unset or set a higher ceiling).

## Behaviour

- `MAX_CATALOGS` **unset** (default): no validation runs, no behaviour change.
- `MAX_CATALOGS=200`: `saveConfig` and `updateConfig` reject payloads where `catalogs.length > 200` with a `400` and a structured response:

  ```json
  {
    "error": "Too many catalogs (845); the maximum allowed on this instance is 200. Remove some catalogs and try again.",
    "catalogCount": 845,
    "maxCatalogs": 200
  }
  ```

  The `catalogCount` and `maxCatalogs` fields let the frontend surface a useful message without regex-parsing the string.

- Existing configs above the limit continue to serve (reads unaffected). Users only encounter the check when they next save, at which point they trim and retry.

## Changes

- New `validateCatalogCount(config)` method on `ConfigApi`.
- Called from both `saveConfig` (new configs) and `updateConfig` (edits), right after the existing `validateRequiredKeys` check.
- Single file change: `addon/lib/configApi.js` (+45 / -3).

## Test plan

- [x] `node --check` passes
- [x] With `MAX_CATALOGS` unset, no-op (tested locally)
- [ ] With `MAX_CATALOGS=200`, a save with 845 catalogs returns 400 with structured body
- [ ] With `MAX_CATALOGS=200`, a save with 200 catalogs is accepted
- [ ] Reading an existing user with >200 catalogs still works (read path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)