### PR TITLE
Shorten TMDB request timeout and retries; make env-tunable

### DIFF
--- a/addon/lib/getTmdb.ts
+++ b/addon/lib/getTmdb.ts
@@ -119,7 +119,12 @@ async function makeTmdbRequest(endpoint: string, apiKey: string, params: Record<
   const url = `${TMDB_API_URL}${endpoint}?${queryParams.toString()}`;
 
   let attempt = 0;
-  const maxRetries = 3;
+  // Env-tunable so operators can shed load faster during TMDB brownouts. Defaults
+  // (5s × 2 attempts = 10s worst case) replace the previous 15s × 3 = 45s, which
+  // let in-flight state pile up in memory during upstream slowdowns and drove
+  // heap OOMs on busy instances.
+  const maxRetries = Math.max(1, parseInt(process.env.TMDB_MAX_RETRIES || '2', 10));
+  const requestTimeoutMs = Math.max(1000, parseInt(process.env.TMDB_REQUEST_TIMEOUT_MS || '5000', 10));
   let lastError: any;
 
   while(attempt < maxRetries) {
@@ -132,7 +137,7 @@ async function makeTmdbRequest(endpoint: string, apiKey: string, params: Record<
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         dispatcher: dispatcher,
         body: body ? JSON.stringify(body) : undefined,
-        signal: AbortSignal.timeout(15000)
+        signal: AbortSignal.timeout(requestTimeoutMs)
       });
 
       const responseTime = Date.now() - startTime;


### PR DESCRIPTION
## Summary

Cut TMDB per-request timeout from 15s → 5s and max attempts from 3 → 2, both env-tunable. Worst-case held time per request drops from **45s to 10s**.

## Motivation

Under upstream TMDB brownouts (observed on a busy public instance), every concurrent TMDB call was holding its response buffer + promise chain for up to 45 seconds waiting on retries. A single manifest load fans out to dozens of TMDB calls; concurrent user traffic multiplies that. During a brief TMDB slowdown, the in-flight state stacked up faster than GC could reclaim it, taking the process to OOM even with `--max-old-space-size=8192`.

Example from the recent incident:
```
[Meta] WARN [MovieMeta] TMDB fallback failed for tmdb:1241921: The operation was aborted due to timeout
[Meta] WARN [MovieMeta] TMDB fallback failed for tmdb:1125257: The operation was aborted due to timeout
... [50+ more in a few seconds] ...
[Trakt] Up Next: fetchTraktUpNextEpisodes took 124964ms   <-- single request, 2+ minutes
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

The process wasn't leaking memory — it was holding 8 GB of concurrent pending-TMDB-request state. Raising the heap limit doesn't help; shedding load faster does.

## Change

Two one-line swaps in `makeTmdbRequest`:

```diff
- const maxRetries = 3;
+ const maxRetries = Math.max(1, parseInt(process.env.TMDB_MAX_RETRIES || '2', 10));
+ const requestTimeoutMs = Math.max(1000, parseInt(process.env.TMDB_REQUEST_TIMEOUT_MS || '5000', 10));

- signal: AbortSignal.timeout(15000)
+ signal: AbortSignal.timeout(requestTimeoutMs)
```

## New env vars

| Var | Default | Prior behaviour |
|---|---|---|
| `TMDB_REQUEST_TIMEOUT_MS` | `5000` | 15000 (hard-coded) |
| `TMDB_MAX_RETRIES` | `2` | 3 (hard-coded) |

Self-hosters with private TMDB keys and spare quota can raise these back to prior values if they prefer aggressive retrying. Operators hitting rate limits or upstream flakiness can tune down further.

## What's preserved

- 429 backoff via `Retry-After` header — untouched
- Non-retryable codes fast-fail path — untouched
- Error classification and logging — untouched
- The `scrapedImdbIdCache` clear — untouched

## Follow-ups (not in this PR)

Similar timeout/retry tuning is warranted for: TVmaze (75s worst case), Trakt (90s), AniList (90s), MAL/Jikan (45s), MDBList (50s), Letterboxd (90s), IMDb Ratings (120s), TVDB (24s). Keeping this PR focused on TMDB since that's the one in the incident log and the most frequently hit provider.

## Test plan

- [x] `node --check` on modified file
- [x] Applies cleanly against current `dev`
- [ ] With defaults, verify typical TMDB latency stays well under 5s (normal TMDB is ~200-800ms)
- [ ] Under induced upstream slowness, verify requests fail fast at 5-10s instead of 45s
- [ ] Confirm `Retry-After` handling still works for 429 responses (existing test path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)