### PR TITLE
Cache TMDB /trending and TVDB /search/remoteid results globally

### DIFF
--- a/addon/lib/getTmdb.ts
+++ b/addon/lib/getTmdb.ts
@@ -807,8 +807,18 @@ export async function getTmdbSeriesLogo(tmdbId: string, config: UserConfig) {
   }
 }
 
+// Trending results are globally identical for (media_type, time_window, language,
+// page) — not user-specific — and the list only meaningfully shifts on the hour
+// or day scale. Cache globally so we don't fan out one TMDB call per user's
+// trending-catalog cache refresh. Before this: N users × M language/page
+// combinations = N·M TMDB calls per refresh. After: one per unique tuple per TTL.
 export async function trending(params: any, config: UserConfig) {
-    return makeTmdbRequest(`/trending/${params.media_type}/${params.time_window}`, getApiKey(config), params, 'GET', null, config);
+    const { media_type, time_window, language, page } = params;
+    const cacheKey = `tmdb:trending:${media_type}:${time_window}:${language || 'default'}:${page || 1}`;
+    return cacheWrapGlobal(cacheKey, () =>
+        makeTmdbRequest(`/trending/${media_type}/${time_window}`, getApiKey(config), params, 'GET', null, config),
+        60 * 60 // 1 hour — trending shifts within the day but not second-to-second
+    );
 }
 
 export async function seasonInfo(params: any, config: UserConfig) {

--- a/addon/lib/tvdb.ts
+++ b/addon/lib/tvdb.ts
@@ -812,65 +812,72 @@ async function getSeriesEpisodes(tvdbId: string, language: string = 'en-US', sea
   });
 }
 
+// IMDb ID → TVDB ID mapping is immutable per title. Wrap in global cache so
+// the id-resolver doesn't re-hit TVDB on every meta request for the same
+// external ID. Same for findByTmdbId below.
 async function findByImdbId(imdbId: string, config: UserConfig): Promise<TvdbSearchResult[]> {
   const token = await getAuthToken(config.apiKeys?.tvdb, config.userUUID);
   if (!token) return [];
-  
-  const startTime = Date.now();
-  try {
-    const response = await tvdbHttpRequest(`${TVDB_API_URL}/search/remoteid/${imdbId}`, {
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    
-    const responseTime = Date.now() - startTime;
-    
-    // Track successful request
-    const requestTracker = require('./requestTracker');
-    requestTracker.trackProviderCall('tvdb', responseTime, true);
-    
-    const results = (response.data as any)?.data || [];
-    const consola = require('consola');
-    consola.debug(`[TVDB] Found TVDB ID for IMDB ID ${imdbId}:`, results);
-    return results;
-  } catch (error) {
-    // Track failed request
-    const responseTime = Date.now() - startTime;
-    const requestTracker = require('./requestTracker');
-    requestTracker.trackProviderCall('tvdb', responseTime, false);
-    
-    logger.error(`[findByImdbId] Error finding TVDB by IMDb ID ${imdbId}:`, (error as Error).message);
-    return [];
-  }
+
+  return cacheWrapTvdbApi(`remoteid:imdb:${imdbId}`, async () => {
+    const startTime = Date.now();
+    try {
+      const response = await tvdbHttpRequest(`${TVDB_API_URL}/search/remoteid/${imdbId}`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+
+      const responseTime = Date.now() - startTime;
+
+      // Track successful request
+      const requestTracker = require('./requestTracker');
+      requestTracker.trackProviderCall('tvdb', responseTime, true);
+
+      const results = (response.data as any)?.data || [];
+      const consola = require('consola');
+      consola.debug(`[TVDB] Found TVDB ID for IMDB ID ${imdbId}:`, results);
+      return results;
+    } catch (error) {
+      // Track failed request
+      const responseTime = Date.now() - startTime;
+      const requestTracker = require('./requestTracker');
+      requestTracker.trackProviderCall('tvdb', responseTime, false);
+
+      logger.error(`[findByImdbId] Error finding TVDB by IMDb ID ${imdbId}:`, (error as Error).message);
+      return [];
+    }
+  });
 }
 
 async function findByTmdbId(tmdbId: string, config: UserConfig): Promise<TvdbSearchResult[]> {
   const token = await getAuthToken(config.apiKeys?.tvdb, config.userUUID);
   if (!token) return [];
-  
-  const startTime = Date.now();
-  try {
-    const response = await tvdbHttpRequest(`${TVDB_API_URL}/search/remoteid/${tmdbId}`, {
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    
-    const responseTime = Date.now() - startTime;
-    
-    // Track successful request
-    const requestTracker = require('./requestTracker');
-    requestTracker.trackProviderCall('tvdb', responseTime, true);
-    
-    const results = (response.data as any)?.data || [];
-    
-    return results;
-  } catch (error) {
-    // Track failed request
-    const responseTime = Date.now() - startTime;
-    const requestTracker = require('./requestTracker');
-    requestTracker.trackProviderCall('tvdb', responseTime, false);
-    
-    logger.error(`[findByTmdbId] Error finding TVDB by TMDB ID ${tmdbId}:`, (error as Error).message);
-    return [];
-  }
+
+  return cacheWrapTvdbApi(`remoteid:tmdb:${tmdbId}`, async () => {
+    const startTime = Date.now();
+    try {
+      const response = await tvdbHttpRequest(`${TVDB_API_URL}/search/remoteid/${tmdbId}`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+
+      const responseTime = Date.now() - startTime;
+
+      // Track successful request
+      const requestTracker = require('./requestTracker');
+      requestTracker.trackProviderCall('tvdb', responseTime, true);
+
+      const results = (response.data as any)?.data || [];
+
+      return results;
+    } catch (error) {
+      // Track failed request
+      const responseTime = Date.now() - startTime;
+      const requestTracker = require('./requestTracker');
+      requestTracker.trackProviderCall('tvdb', responseTime, false);
+
+      logger.error(`[findByTmdbId] Error finding TVDB by TMDB ID ${tmdbId}:`, (error as Error).message);
+      return [];
+    }
+  });
 }
 
 async function getAllGenres(config: UserConfig): Promise<TvdbGenre[]> {


### PR DESCRIPTION
## Summary

Wrap two uncached provider endpoints in the existing global cache layer. Both return data that is identical across users, so a per-user cache miss currently fans out to N upstream calls for the same answer. Post-patch, one upstream call per unique tuple per TTL.

## Motivation

Audit of cache coverage across provider modules found that most high-leverage calls are already wrapped at an outer layer (getMeta → cacheWrapMetaSmart, search → cacheWrapSearch, discover → cacheWrapCatalog). The gaps are two endpoints where the outer cache is user-scoped, so one miss = one upstream call *per user*:

- **TMDB `/trending/{type}/{window}`** — called from `getTrending` which feeds the trending catalog. Catalog cache is per-user; trending-list *contents* are globally identical for (media_type, time_window, language, page). With N active users refreshing trending, that's N TMDB calls for the same list.
- **TVDB `/search/remoteid/{id}`** — called from id-resolver on every meta/catalog request that needs cross-reference IDs. IMDb → TVDB and TMDB → TVDB mappings are permanent per title, so not caching them is pure waste.

On a busy multi-tenant instance, both of these were visibly hot paths during TMDB / TVDB brownouts.

## Changes

### `addon/lib/getTmdb.ts`
```diff
 export async function trending(params: any, config: UserConfig) {
-    return makeTmdbRequest(`/trending/${params.media_type}/${params.time_window}`, getApiKey(config), params, 'GET', null, config);
+    const { media_type, time_window, language, page } = params;
+    const cacheKey = `tmdb:trending:${media_type}:${time_window}:${language || 'default'}:${page || 1}`;
+    return cacheWrapGlobal(cacheKey, () =>
+        makeTmdbRequest(`/trending/${media_type}/${time_window}`, getApiKey(config), params, 'GET', null, config),
+        60 * 60 // 1 hour — trending shifts within the day but not second-to-second
+    );
 }
```

### `addon/lib/tvdb.ts`
Both `findByImdbId` and `findByTmdbId` wrapped in `cacheWrapTvdbApi(\`remoteid:imdb|tmdb:{id}\`, ...)` — uses the existing 12h TTL configured via `TVDB_API_TTL`. Body of each function is unchanged, just wrapped.

## What's preserved

- 429 backoff and retry logic — untouched
- All error telemetry via `requestTracker.trackProviderCall` — untouched
- Function signatures and return types — unchanged (still return `TvdbSearchResult[]`)

## What's explicitly NOT changed

- `/movie/{id}`, `/tv/{id}`, `/movie/{id}/credits` etc. — already cached at the outer `cacheWrapMetaSmart` layer. Wrapping here would be redundant and could cause cache key mismatches with the meta-component reconstruction path.
- `/search/movie`, `/search/tv` — already cached at `cacheWrapSearch` (per user, keyed by config hash + query). Caching at the TMDB layer would be incorrect (adult-content setting and language vary per user).
- `/discover/movie`, `/discover/tv` — already cached at `cacheWrapCatalog`.

## Test plan

- [x] `tsc --noEmit` — passes
- [x] Applies cleanly against current `dev`
- [ ] Verify trending catalog still serves fresh data within 1h TTL
- [ ] Verify id-resolver still returns correct TVDB IDs for known IMDb/TMDB references
- [ ] Monitor TVDB `/search/remoteid` and TMDB `/trending` call volume post-deploy — should drop significantly vs. active user count

## Relationship to other PRs

Independent of #445, #446, #451, #452. Touches different code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)