### PR TITLE
Scope MDBList items cache globally for public lists

### DIFF
--- a/addon/utils/mdbList.ts
+++ b/addon/utils/mdbList.ts
@@ -302,9 +302,16 @@ async function fetchMDBListItems(listId: string, apiKey: string, language: strin
   // Use configurable page size (supports CATALOG_LIST_ITEMS_SIZE env var)
   const pageSize = parseInt(process.env.CATALOG_LIST_ITEMS_SIZE as string) || 20;
   
+  // Cache scoping: /watchlist/items is per-user (the user's own list), so the
+  // cache key must include the API key. /lists/{listId}/items returns a public
+  // list whose contents are identical regardless of which API key queried —
+  // scope that globally so N users hitting the same public list share one
+  // cache entry instead of each building their own.
+  const isPrivateList = listId === 'watchlist';
   const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 16);
-  
-  const cacheKey = `mdblist-api:items:${apiKeyHash}:${listId}:${page}:${sort || ''}:${order || ''}:${genre || ''}:${unified !== false}:${catalogType || ''}:${pageSize}`;
+  const keyScope = isPrivateList ? `user:${apiKeyHash}` : 'public';
+
+  const cacheKey = `mdblist-api:items:${keyScope}:${listId}:${page}:${sort || ''}:${order || ''}:${genre || ''}:${unified !== false}:${catalogType || ''}:${pageSize}`;
   
   const ttl = cacheTTL !== undefined ? cacheTTL : parseInt(process.env.CATALOG_TTL || String(1 * 24 * 60 * 60), 10);
   


### PR DESCRIPTION
## Summary

Small change to `fetchMDBListItems` that drops the API-key dimension from the cache key when the underlying list is public. For the user's own `/watchlist`, nothing changes.

## Motivation

`fetchMDBListItems` already wraps requests in `cacheWrapGlobal`, but the cache key includes `apiKeyHash`:

```ts
const cacheKey = `mdblist-api:items:${apiKeyHash}:${listId}:${page}:...`;
```

This means: 100 users each with a different MDBList API key querying the same public list ID = 100 separate cache entries = 100 upstream calls for what is the same response body. The MDBList API requires `apikey` on every request for auth, but the response body for `/lists/{listId}/items` is not user-specific.

For `/watchlist/items` the API key *does* identify the user, so the apiKey-scoped cache is correct there and must stay.

## Change

```diff
-  const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 16);
-  
-  const cacheKey = `mdblist-api:items:${apiKeyHash}:${listId}:${page}:...`;
+  // Cache scoping: /watchlist/items is per-user, /lists/{listId}/items is public.
+  const isPrivateList = listId === 'watchlist';
+  const apiKeyHash = crypto.createHash('sha256').update(apiKey).digest('hex').substring(0, 16);
+  const keyScope = isPrivateList ? `user:${apiKeyHash}` : 'public';
+
+  const cacheKey = `mdblist-api:items:${keyScope}:${listId}:${page}:...`;
```

## Impact

- Public list cache entries collapse from O(N users) to O(1) per (listId, page, sort, order, genre, unified, catalogType, pageSize) tuple.
- Cache footprint in Redis shrinks significantly for deployments with many users sharing catalogs.
- Upstream call volume drops proportionally — on a busy public instance this is likely the single largest MDBList-side reduction available.
- Watchlist behaviour is unchanged: still per-user-correct.

## What's preserved

- TTL — unchanged (caller-provided or `CATALOG_TTL` env, default 24h)
- Rate limiting (`makeRateLimitedRequest`, globalThrottle) — untouched
- `apikey` query parameter on actual HTTP requests — still sent (required by MDBList)
- Error handling, pagination extraction — untouched

## Test plan

- [x] `tsc --noEmit` — passes
- [x] Applies cleanly against current `dev`
- [ ] Verify: two users with different API keys querying the same public list hit the same cache entry on the second request
- [ ] Verify: `/watchlist/items` for two different users still returns their respective watchlists (separate cache entries)

## Context

This is part of a series of efficiency/memory PRs against #445, #446, #451, #452, #453. Each is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)