### PR TITLE
Normalize TMDB 'tv' type in getMeta; use finalType for resolveAllIds

### DIFF
--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -242,6 +242,10 @@ async function getMeta(type, language, stremioId, config = {}, userUUID, include
       logger.error(`[Meta] Invalid stremioId: ${stremioId}`);
       return { meta: null };
     }
+    // Defensive normalization: some upstream providers (Simkl, raw TMDB responses,
+    // etc.) use TMDB's 'tv' convention for series. Normalize here so resolveAllIds
+    // and the finalType switch below don't silently reject the request.
+    if (type === 'tv') type = 'series';
     
     // --- Handle custom ID prefixes (e.g., "tun_tt6128300") ---
     const isTraktUpNextId = stremioId.startsWith('tun_');
@@ -355,7 +359,9 @@ async function getMeta(type, language, stremioId, config = {}, userUUID, include
       targetProviders.add(preferredProvider);
     }
     logger.debug(`[Meta] Target providers: ${Array.from(targetProviders)}`);
-    const allIds =  await resolveAllIds(stremioId, type, config, {}, Array.from(targetProviders));
+    // Use finalType (which maps animeId stremioIds to 'anime') rather than raw
+    // type so id-resolver's targetProviders heuristics pick the anime path.
+    const allIds =  await resolveAllIds(stremioId, finalType, config, {}, Array.from(targetProviders));
     switch (finalType) {
       case 'movie':
         meta = await getMovieMeta(stremioId, preferredProvider, language, config, userUUID, allIds);


### PR DESCRIPTION
## Summary

Two small fixes in `addon/lib/getMeta.js`:
1. Normalize `type === 'tv'` to `'series'` at function entry so upstream providers passing TMDB's convention don't cause silent resolution failures.
2. Pass `finalType` (not raw `type`) to `resolveAllIds` so anime ID resolution takes the anime path.

## Motivation

On a busy production instance, the following warning was firing constantly — several dozen times per minute:

```
[ID-Resolver] WARN Invalid type: tv
```

[addon/lib/id-resolver.js:260](https://github.com/cedya77/aiometadata/blob/dev/addon/lib/id-resolver.js#L260) rejects anything that isn't `'movie' | 'series' | 'anime'` and returns `null`, meaning the meta request gets no cross-reference IDs and falls through to a degraded response. 

Tracing back: upstream providers (Simkl sync endpoints, raw TMDB responses proxied via StremThru, etc.) sometimes pass `type: 'tv'` (TMDB's convention) instead of `'series'`. The value flows through `getMeta → resolveAllIds` untouched.

## Changes

### 1. Defensive type normalization at getMeta entry

```diff
 async function getMeta(type, language, stremioId, config = {}, userUUID, includeVideos = true) {
   try {
     // Validate inputs
     if (!stremioId || typeof stremioId !== 'string') {
       logger.error(`[Meta] Invalid stremioId: ${stremioId}`);
       return { meta: null };
     }
+    // Defensive normalization: some upstream providers (Simkl, raw TMDB responses,
+    // etc.) use TMDB's 'tv' convention for series. Normalize here so resolveAllIds
+    // and the finalType switch below don't silently reject the request.
+    if (type === 'tv') type = 'series';
```

Catches the bug at a single choke point rather than playing whack-a-mole across every upstream parser.

### 2. Use `finalType` for `resolveAllIds`

```diff
-    const allIds =  await resolveAllIds(stremioId, type, config, {}, Array.from(targetProviders));
+    // Use finalType (which maps animeId stremioIds to 'anime') rather than raw
+    // type so id-resolver's targetProviders heuristics pick the anime path.
+    const allIds =  await resolveAllIds(stremioId, finalType, config, {}, Array.from(targetProviders));
```

`finalType` is computed earlier (line ~302):
```ts
const finalType = isAnime ? 'anime' : type;
```

The switch on the very next line already uses `finalType`. The `resolveAllIds` call was an obvious pre-existing typo — when the stremioId is an anime ID (e.g. `anilist:12345`), we want the resolver to know.

## What's preserved

- No behaviour change for callers that already pass `'movie'`/`'series'`/`'anime'` — those paths are untouched.
- Error handling, caching, provider selection — all unchanged.

## Test plan

- [x] `node --check` passes
- [x] Applies cleanly against `dev`
- [ ] After deploy: confirm `[ID-Resolver] WARN Invalid type: tv` disappears from logs
- [ ] Confirm anime meta requests (anilist:/mal:/kitsu:/anidb: prefixes) still resolve correctly and anime-specific providers are reached

## Context

Independent of #445, #446, #451, #452, #453, #454. Touches only `addon/lib/getMeta.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)