### PR TITLE
feat: optional art URL overrides in search results

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3805,7 +3805,7 @@ addon.get("/stremio/:userUUID/catalog/:type/:id{/:extra}.json", async function (
     // (when disabled, up next uses episode thumbnails as posters which shouldn't be overridden)
     const host = process.env.HOST_NAME.startsWith('http') ? process.env.HOST_NAME : `https://${process.env.HOST_NAME}`;
     const posterPatternsEnabled = config._currentSearchCatalogId
-      ? (config.search?.engineRatingPosters?.[config._currentSearchCatalogId] === true)
+      ? (config.search?.engineRatingPosters?.[config._currentSearchCatalogId] === true || config.artProviders?.searchArtUrlOverrides === true)
       : (catalogConfig?.enableRatingPosters !== false);
     const posterPattern = posterPatternsEnabled ? (config.customPosterUrlPattern || (config.posterRatingProvider && config.posterRatingProvider !== 'custom' ? require('./utils/parseProps').getDefaultPosterPattern(config.posterRatingProvider) : null)) : null;
     if ((posterPattern || config.customBackgroundUrlPattern || config.customLogoUrlPattern) && responseData?.metas && Array.isArray(responseData.metas)) {

--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -348,7 +348,12 @@ class ConfigApi {
               artProvidersChanged = true;
               logger.debug(`englishArtOnly changed from ${oldConfig?.artProviders?.englishArtOnly} to ${config.artProviders?.englishArtOnly}`);
             }
-            
+
+            if (config.artProviders?.searchArtUrlOverrides !== oldConfig?.artProviders?.searchArtUrlOverrides) {
+              artProvidersChanged = true;
+              logger.debug(`searchArtUrlOverrides changed from ${oldConfig?.artProviders?.searchArtUrlOverrides} to ${config.artProviders?.searchArtUrlOverrides}`);
+            }
+
             // Check each content type (movie, series, anime)
             const contentTypes = ['movie', 'series', 'anime'];
             for (const contentType of contentTypes) {
@@ -690,7 +695,12 @@ class ConfigApi {
               artProvidersChanged = true;
               logger.debug(`englishArtOnly changed from ${oldConfig?.artProviders?.englishArtOnly} to ${config.artProviders?.englishArtOnly}`);
             }
-            
+
+            if (config.artProviders?.searchArtUrlOverrides !== oldConfig?.artProviders?.searchArtUrlOverrides) {
+              artProvidersChanged = true;
+              logger.debug(`searchArtUrlOverrides changed from ${oldConfig?.artProviders?.searchArtUrlOverrides} to ${config.artProviders?.searchArtUrlOverrides}`);
+            }
+
             // Check each content type (movie, series, anime)
             const contentTypes = ['movie', 'series', 'anime'];
             for (const contentType of contentTypes) {

--- a/configure/src/components/sections/ArtProviderSettings.tsx
+++ b/configure/src/components/sections/ArtProviderSettings.tsx
@@ -136,7 +136,7 @@ export function ArtProviderSettings() {
         <div className="flex items-start gap-2 mt-4 p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
           <AlertCircle className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
           <p className="text-sm text-blue-800 dark:text-blue-200">
-            <strong>Note:</strong> Art provider settings apply to catalogs and detail pages, but not to search results. Search uses the selected search engine's poster sources for faster performance. <strong>Art URL Overrides (configured below) take priority over art provider settings.</strong>
+            <strong>Note:</strong> Art provider settings apply to catalogs and detail pages, but not to search results. Search uses the selected search engine's poster sources for faster performance, unless you enable <strong>Art URL Overrides in Search</strong> below. <strong>Art URL Overrides (configured below) take priority over art provider settings.</strong>
           </p>
         </div>
         
@@ -176,6 +176,26 @@ export function ArtProviderSettings() {
                 id="original-lang-fallback"
                 checked={!!config.artProviders?.originalLangFallback}
                 onCheckedChange={(value) => setConfig(prev => ({ ...prev, artProviders: { ...prev.artProviders, originalLangFallback: value } }))}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="search-art-url-overrides" className="text-base font-medium">
+                  Art URL Overrides in Search
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  Apply your Art URL Overrides to search results too. Search may be slightly slower, but posters stay consistent with your catalogs.
+                </p>
+              </div>
+              <Switch
+                id="search-art-url-overrides"
+                checked={!!config.artProviders?.searchArtUrlOverrides}
+                onCheckedChange={(value) => setConfig(prev => ({ ...prev, artProviders: { ...prev.artProviders, searchArtUrlOverrides: value } }))}
               />
             </div>
           </CardContent>

--- a/configure/src/contexts/ConfigContext.tsx
+++ b/configure/src/contexts/ConfigContext.tsx
@@ -120,7 +120,8 @@ const initialConfig: AppConfig = {
     series: { poster: 'meta', background: 'meta', logo: 'meta' },
     anime: { poster: 'meta', background: 'imdb', logo: 'imdb' },
     englishArtOnly: false,
-    originalLangFallback: false
+    originalLangFallback: false,
+    searchArtUrlOverrides: false
   },
   tvdbSeasonType: 'default',
   mal: {
@@ -347,6 +348,9 @@ export function ConfigProvider({ children }: { children: React.ReactNode }) {
           }
           if (userArtProviders.originalLangFallback !== undefined) {
             migratedArtProviders.originalLangFallback = userArtProviders.originalLangFallback;
+          }
+          if (userArtProviders.searchArtUrlOverrides !== undefined) {
+            migratedArtProviders.searchArtUrlOverrides = userArtProviders.searchArtUrlOverrides;
           }
           
           return migratedArtProviders;

--- a/configure/src/contexts/config.ts
+++ b/configure/src/contexts/config.ts
@@ -135,6 +135,7 @@ export interface AppConfig {
     };
     englishArtOnly: boolean;
     originalLangFallback: boolean;
+    searchArtUrlOverrides: boolean;
   };
   tvdbSeasonType: string;
   mal: {


### PR DESCRIPTION
## Summary

Art URL Overrides previously applied to catalogs and detail pages but not to search results, so custom posters (e.g. a PostersPlus instance) were inconsistent in search. This adds an optional **Art URL Overrides in Search** toggle to the Art Providers section. When enabled, search results use the configured custom poster patterns instead of the search engine's own poster sources, trading slightly slower search for poster consistency.

## Linked issue

Closes #533

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

Search runs through the catalog route, where poster overrides were gated by `posterPatternsEnabled` — for the search context this required `engineRatingPosters[catalogId] === true`, so custom Art URL Overrides were skipped for posters (background/logo already applied). Rather than add a new code path, the change extends that existing gate with an opt-in flag, keeping the behavior consistent with how overrides already work elsewhere. The flag defaults to **off** so existing users see no change and search stays fast. Cache invalidation on the flag is wired into the existing `artProviders` change detection so toggling takes effect immediately.

## Testing

Built and ran the addon locally (SQLite + Redis), installed it in Stremio, configured a custom poster URL pattern, and confirmed search results render the custom posters only when the toggle is enabled, and fall back to the search engine's posters when disabled.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

No automated tests exist for the search poster-override path; the change is a config-gated behavior switch verified manually end-to-end in Stremio.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

Updated the in-app Art Providers note banner to mention the new toggle. No external docs cover this area.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

AI assistance (Claude Code) was used to locate the relevant code, implement the toggle, and wire up config/migration/cache invalidation. I reviewed every change and verified the behavior end-to-end in Stremio before submitting.