### PR TITLE
feat: add TMDB original language exclusions

### DIFF
--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -23,6 +23,7 @@ import { getTVDBContentRatingId } from '../utils/tvdbContentRating.js';
 import { getMeta } from './getMeta.js';
 import { resolveDynamicTmdbDiscoverParams } from './tmdbDiscoverDateTokens.js';
 import { roundRobinInterleaveTagged, mergedDedupKey, filterMetasByGenre, normalizeGenreKey } from '../utils/mergedCatalog.js';
+import { filterByExcludedOriginalLanguages } from '../utils/original-language-filters.js';
 const { getTvmazeScheduleCatalog } = require('./tvmazeScheduleCatalog');
 
 const consola = require('consola');
@@ -994,8 +995,18 @@ async function getTmdbAndMdbListCatalog(type: string, id: string, genre: string,
         return [];
       }
 
+      const filteredResults = filterByExcludedOriginalLanguages(
+        response.results,
+        discoverMetadata?.excludedOriginalLanguages
+      );
+
+      if (filteredResults.length === 0) {
+        logger.info(`[TMDB Discover] No results for ${id} after original language exclusions`);
+        return [];
+      }
+
       const metaType = mediaType === 'movie' ? 'movie' : 'series';
-      const metas = await mapWithLimit(response.results, async (item: any) => {
+      const metas = await mapWithLimit(filteredResults, async (item: any) => {
         const stremioId = `tmdb:${item.id}`;
 
         try {

--- a/addon/utils/original-language-filters.test.js
+++ b/addon/utils/original-language-filters.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { filterByExcludedOriginalLanguages } = require('./original-language-filters');
+
+test('filters TMDB items with excluded original languages', () => {
+  const items = [
+    { id: 1, original_language: 'en' },
+    { id: 2, original_language: 'hi' },
+    { id: 3, original_language: 'id' },
+    { id: 4, original_language: 'fr' },
+    { id: 5 },
+  ];
+
+  const filtered = filterByExcludedOriginalLanguages(items, ['hi', 'id']);
+
+  assert.deepEqual(filtered.map(item => item.id), [1, 4, 5]);
+});
+
+test('normalizes excluded original language codes before filtering', () => {
+  const items = [
+    { id: 1, original_language: 'JA' },
+    { id: 2, original_language: 'ko' },
+    { id: 3, original_language: 'es' },
+  ];
+
+  const filtered = filterByExcludedOriginalLanguages(items, [' ja ', 'KO', '', '  ']);
+
+  assert.deepEqual(filtered.map(item => item.id), [3]);
+});

--- a/addon/utils/original-language-filters.ts
+++ b/addon/utils/original-language-filters.ts
@@ -1,0 +1,24 @@
+export function normalizeOriginalLanguageCodes(languages: unknown): string[] {
+  if (!Array.isArray(languages)) return [];
+
+  return Array.from(new Set(
+    languages
+      .map(language => String(language).trim().toLowerCase())
+      .filter(Boolean)
+  ));
+}
+
+export function filterByExcludedOriginalLanguages<T extends { original_language?: unknown }>(
+  items: T[],
+  excludedOriginalLanguages: unknown
+): T[] {
+  const excluded = new Set(normalizeOriginalLanguageCodes(excludedOriginalLanguages));
+  if (excluded.size === 0) return items;
+
+  return items.filter(item => {
+    const originalLanguage = typeof item.original_language === 'string'
+      ? item.original_language.trim().toLowerCase()
+      : '';
+    return !originalLanguage || !excluded.has(originalLanguage);
+  });
+}

--- a/configure/src/components/sections/DiscoverBuilderDialog.tsx
+++ b/configure/src/components/sections/DiscoverBuilderDialog.tsx
@@ -757,6 +757,8 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
   const [pendingExcludeGenreId, setPendingExcludeGenreId] = useState<string>('');
 
   const [originalLanguage, setOriginalLanguage] = useState('');
+  const [excludedOriginalLanguages, setExcludedOriginalLanguages] = useState<string[]>([]);
+  const [pendingExcludedOriginalLanguage, setPendingExcludedOriginalLanguage] = useState('');
   const [originCountry, setOriginCountry] = useState('');
   const [releaseRegion, setReleaseRegion] = useState('');
   const [certificationCountry, setCertificationCountry] = useState('');
@@ -952,6 +954,11 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
     [references]
   );
 
+  const availableExcludedOriginalLanguages = useMemo(
+    () => sortedLanguages.filter(languageItem => !excludedOriginalLanguages.includes(languageItem.iso_639_1)),
+    [excludedOriginalLanguages, sortedLanguages]
+  );
+
   const sortedCountries = useMemo(
     () => (references?.countries || []).slice().sort((a, b) => (a.english_name || a.iso_3166_1).localeCompare(b.english_name || b.iso_3166_1)),
     [references]
@@ -1144,6 +1151,8 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
     setPendingExcludeGenreId('');
 
     setOriginalLanguage('');
+    setExcludedOriginalLanguages([]);
+    setPendingExcludedOriginalLanguage('');
     setOriginCountry('');
     setReleaseRegion('');
     setCertificationCountry('');
@@ -1272,6 +1281,7 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
     if (fs.excludeGenres) setExcludeGenres(fs.excludeGenres);
     if (fs.genreJoinMode) setGenreJoinMode(fs.genreJoinMode);
     if (fs.originalLanguage) setOriginalLanguage(fs.originalLanguage);
+    if (Array.isArray(fs.excludedOriginalLanguages)) setExcludedOriginalLanguages(fs.excludedOriginalLanguages);
     if (fs.originCountry) setOriginCountry(fs.originCountry);
     if (fs.certificationCountry) setCertificationCountry(fs.certificationCountry);
     if (fs.certificationValue) setCertificationValue(fs.certificationValue);
@@ -1411,6 +1421,7 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
     if (fs.voteAverageRange) setVoteAverageRange(fs.voteAverageRange);
     if (fs.runtimeRange) setRuntimeRange(fs.runtimeRange);
     if (fs.originalLanguage) setOriginalLanguage(fs.originalLanguage);
+    if (Array.isArray(fs.excludedOriginalLanguages)) setExcludedOriginalLanguages(fs.excludedOriginalLanguages);
     if (fs.originCountry) setOriginCountry(fs.originCountry);
     if (fs.primaryReleaseFrom) setPrimaryReleaseFrom(fs.primaryReleaseFrom);
     if (fs.primaryReleaseTo) setPrimaryReleaseTo(fs.primaryReleaseTo);
@@ -2306,6 +2317,7 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
         includeAdult,
         releasedOnly,
         tmdbTvStatuses,
+        excludedOriginalLanguages,
         selectedPeople,
         peopleJoinMode,
         withCompanies,
@@ -2469,6 +2481,21 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
     }
   };
 
+  const getLanguageLabel = (code: string) => {
+    const languageItem = sortedLanguages.find(item => item.iso_639_1 === code);
+    return `${languageItem?.english_name || languageItem?.name || code} (${code})`;
+  };
+
+  const handleAddExcludedOriginalLanguage = () => {
+    if (!pendingExcludedOriginalLanguage) return;
+    setExcludedOriginalLanguages(prev => (
+      prev.includes(pendingExcludedOriginalLanguage)
+        ? prev
+        : [...prev, pendingExcludedOriginalLanguage]
+    ));
+    setPendingExcludedOriginalLanguage('');
+  };
+
   const handleToggleProvider = (provider: TmdbProvider) => {
     const selection: SelectionItem = { id: provider.provider_id, label: provider.provider_name };
     setWatchProviders(prev => {
@@ -2584,6 +2611,9 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
             source: discoverSource,
             mediaType: discoverMediaType as 'movie' | 'tv' | 'series' | 'anime',
             params: persistedParams,
+            ...(discoverSource === 'tmdb' && excludedOriginalLanguages.length > 0 && {
+              excludedOriginalLanguages,
+            }),
             formState,
           }
         }
@@ -3797,6 +3827,59 @@ export function DiscoverBuilderDialog({ isOpen, onClose, editingCatalog, customi
                           </SelectContent>
                         </Select>
                       </div>
+                      {discoverSource === 'tmdb' && (
+                        <div className="space-y-2">
+                          <Label>Exclude Original Languages</Label>
+                          <div className="flex gap-2">
+                            <Select
+                              value={pendingExcludedOriginalLanguage || NONE_VALUE}
+                              onValueChange={(value) => setPendingExcludedOriginalLanguage(value === NONE_VALUE ? '' : value)}
+                            >
+                              <SelectTrigger>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value={NONE_VALUE}>Select language</SelectItem>
+                                {availableExcludedOriginalLanguages.map(languageItem => (
+                                  <SelectItem key={languageItem.iso_639_1} value={languageItem.iso_639_1}>
+                                    {(languageItem.english_name || languageItem.name || languageItem.iso_639_1)} ({languageItem.iso_639_1})
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={handleAddExcludedOriginalLanguage}
+                              disabled={!pendingExcludedOriginalLanguage}
+                            >
+                              Add
+                            </Button>
+                          </div>
+                          {excludedOriginalLanguages.length > 0 ? (
+                            <div className="flex flex-wrap gap-2">
+                              {excludedOriginalLanguages.map(code => (
+                                <Badge key={code} variant="secondary" className="gap-1 pl-2 pr-1 py-1">
+                                  <span className="max-w-[180px] truncate">{getLanguageLabel(code)}</span>
+                                  <button
+                                    type="button"
+                                    onClick={() => setExcludedOriginalLanguages(prev => prev.filter(item => item !== code))}
+                                    className="rounded-sm p-0.5 hover:bg-background/50"
+                                    aria-label={`Remove ${getLanguageLabel(code)}`}
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                </Badge>
+                              ))}
+                            </div>
+                          ) : (
+                            <p className="text-xs text-muted-foreground">No original languages excluded.</p>
+                          )}
+                          <p className="text-xs text-muted-foreground">
+                            Hide TMDB results whose original language matches any selected language.
+                          </p>
+                        </div>
+                      )}
                       <div className="space-y-2">
                         <Label>{discoverSource === 'tmdb' ? 'Origin Country' : 'Country of Origin'}</Label>
                         <Select value={originCountry || NONE_VALUE} onValueChange={(value) => setOriginCountry(value === NONE_VALUE ? '' : value)}>

--- a/configure/src/contexts/config.ts
+++ b/configure/src/contexts/config.ts
@@ -75,6 +75,7 @@ export interface CatalogConfig {
       source?: 'tmdb' | 'tvdb' | 'anilist' | 'simkl' | 'mal' | 'mdblist';
       mediaType?: 'movie' | 'tv' | 'series' | 'anime';
       params?: Record<string, string | number | boolean>;
+      excludedOriginalLanguages?: string[];
       formState?: Record<string, any>;
     };
     discoverParams?: Record<string, string | number | boolean>;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:backend": "eslint addon scripts",
     "lint:frontend": "eslint configure/src",
     "lint:repo": "eslint eslint.config.js tailwind.config.mts vite.config.mts",
+    "test": "node --test -r ts-node/register addon/**/*.test.js",
     "preview": "vite preview",
     "start": "npm run start:backend"
   },

--- a/tsconfig.backend.json
+++ b/tsconfig.backend.json
@@ -42,6 +42,8 @@
       "node_modules",
       "dist",
       "configure",
+      "**/*.test.js",
+      "**/*.spec.js",
       "**/*.test.ts",
       "**/*.spec.ts"
       ,


### PR DESCRIPTION
## Summary
- add an Exclude Original Languages control to TMDB discover catalog creation/editing
- persist excluded original language codes in discover metadata
- filter TMDB discover results by original_language before metadata expansion

## Test Plan
- npx -y -p node@24 node --test -r ts-node/register addon/**/*.test.js
- npx -y -p node@24 node node_modules/typescript/bin/tsc -p tsconfig.backend.json
- npx -y -p node@24 node node_modules/vite/bin/vite.js build
- npx -y -p node@24 node node_modules/eslint/bin/eslint.js configure/src addon/lib/getCatalog.ts addon/utils/original-language-filters.ts addon/utils/original-language-filters.test.js