### PR TITLE
docs: override X-Forwarded-Host in poster-cache nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ http {
             add_header X-Cache-Status $upstream_cache_status;
 
             proxy_set_header Host $proxy_host;
+            proxy_set_header X-Forwarded-Host $proxy_host;
             proxy_set_header Accept-Encoding "";
         }
     }


### PR DESCRIPTION
## summary
This PR fixes the optional `poster-cache` configuration documented in the `README.md` which got blocked by authentication proxies (like Authelia or Authentik) on cache misses.

When a request to `poster-cache` resulted in a cache MISS, Nginx forwarded the client's `X-Forwarded-Host: poster-cache.yourdomain.com` to the main `aiometadata` service. Because `poster-cache` is not (and should not be) in the whitelist of stremio-addon hostnames, Authelia blocked the request and returned a `302` redirect to the login page, causing the poster to fail to load in native streaming apps (like Stremio or Fusion). 

By explicitly overriding `X-Forwarded-Host` to `$proxy_host`, Authelia correctly evaluates the whitelist of the destination domain (`aiometadata`) instead, allowing the request to bypass auth successfully.

## linked issue
None

## type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (no code change, only README documentation modified)

## why this approach
Overriding the `X-Forwarded-Host` header in the Nginx proxy is the standard and most secure way to handle reverse proxy requests to a downstream service when running behind a forward authentication proxy. It aligns the forwarded host header with the target host header, ensuring correct rule matching in Authelia/Authentik without exposing administrative endpoints on the `poster-cache` domain (such as `/stats` or `/purge`) to public bypass rules.

## testing
- Tested by setting up the modified Nginx configuration behind Traefik + Authelia.
- Verified that unauthenticated client requests for uncached posters now successfully return `200 OK` and load the WebP/JPEG images directly instead of getting blocked with `302` redirects to the login portal.

## documentation
- Modified the Nginx configuration template directly in the `README.md` so that future setups include the fix out of the box.

## author checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## ai usage disclosure
- [x] I used AI tools (Gemini) to help diagnose this header mismatch issue and write the PR description.