### PR TITLE
fix: proxy episode thumbnails so clients can load them

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -4398,7 +4398,15 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
                 userAgent,
               });
               if (resolved) {
-                video.thumbnail = resolved;
+                if (config.usePosterProxy) {
+                  const proxyId = ids.imdbId || (ids.tmdbId ? `tmdb:${ids.tmdbId}` : (ids.tvdbId ? `tvdb:${ids.tvdbId}` : null));
+                  // Episode thumbnails share the show's proxyId; the per-episode url param keeps the proxy cache/etag distinct.
+                  video.thumbnail = proxyId
+                    ? `${host}/background/${metaType}/${proxyId}?fallback=${encodeURIComponent(originalThumb || '')}&url=${encodeURIComponent(resolved)}`
+                    : resolved;
+                } else {
+                  video.thumbnail = resolved;
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Episode thumbnails are the only art type not routed through the poster proxy. Poster, background and logo art are rewritten to `${host}/...?url=<resolved>` when `usePosterProxy` is enabled, but thumbnails were emitted as the raw resolved URL. When the thumbnail pattern points at an internal-only host (e.g. a Docker service name), the client can't reach it and every episode thumbnail renders blank even though the generator works. This routes thumbnails through the existing `/background` proxy the same way, with the original still as fallback.

## Linked issue

Closes #567

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

The other art types already solve this exact problem by wrapping the resolved URL through the app proxy, so the client hits a reachable host and the app fetches the generator server-side. Reusing the existing `/background` handler (episode thumbnails are backdrops) keeps behaviour consistent and adds the same fallback and caching thumbnails were missing, with no new route. The per-episode `url` param keeps the proxy cache/etag distinct even though episodes share the show's proxy id. Only applies when `usePosterProxy` is enabled; otherwise behaviour is unchanged.

## Testing

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

Verified against a live setup: with the internal-host pattern the emitted thumbnail URL is now `${host}/background/...` (client-reachable) instead of the raw internal URL, and the app fetches the generator server-side. `node --check addon/index.js` passes. There is no existing test harness around this meta-art path to extend.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how: used to trace the art-proxy path and confirm the thumbnail branch was the odd one out; the change was reviewed and verified against a live setup.
