### PR TITLE
fix: fall back to tmdb/tvdb/kitsu ids for imdb-less custom art

### DIFF
--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -82,7 +82,34 @@ function resolveCustomArtUrl(pattern, ids, type, config, extra) {
     return resolveRatingPosterUrl(pattern, ids, type, config, extra);
   }
 
-  return resolvePattern(pattern, ids, type, config, extra);
+  const direct = resolvePattern(pattern, ids, type, config, extra);
+  if (direct) return direct;
+
+  return resolveArtIdFallback(pattern, ids, type, config, extra);
+}
+
+/**
+ * When a custom art pattern references {imdb_id} in its path but the IMDb ID is
+ * unavailable (common for anime resolved via TVDB/Kitsu), retry with an available
+ * ID in a form self-hosted art services accept in that slot: tmdb:{type}:{id},
+ * tvdb:{id}, kitsu:{id}. Gated on {imdb_id} sitting in the URL path — a composite
+ * ID is a valid path segment but would corrupt a `?imdb_id=` query parameter.
+ */
+function resolveArtIdFallback(pattern, ids, type, config, extra) {
+  if (!pattern.includes('{imdb_id}') || ids?.imdbId) return null;
+  if (!pattern.split('?')[0].includes('{imdb_id}')) return null;
+
+  const typePrefix = type === 'movie' ? 'movie' : 'series';
+  const altIds = [];
+  if (ids?.tmdbId) altIds.push(`tmdb:${typePrefix}:${ids.tmdbId}`);
+  if (ids?.tvdbId) altIds.push(`tvdb:${ids.tvdbId}`);
+  if (ids?.kitsuId) altIds.push(`kitsu:${ids.kitsuId}`);
+
+  for (const alt of altIds) {
+    const resolved = resolvePattern(pattern, { ...ids, imdbId: alt }, type, config, extra);
+    if (resolved) return resolved;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Custom art patterns that reference `{imdb_id}` (e.g. an episode thumbnail pattern like `/thumbnail/{imdb_id}/S{season}E{episode}.jpg`) resolve to nothing when the title has no IMDb ID, which is common for anime resolved via TVDB or Kitsu. The resolver returned `null` and the image rendered blank even though the art service can serve the episode by another ID. This adds an ID fallback: when `{imdb_id}` is unavailable, retry with an available ID in a form these services accept in the same path slot (`tmdb:{type}:{id}`, `tvdb:{id}`, `kitsu:{id}`).

## Linked issue

Closes #568

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

It mirrors the existing RPDB/TOP id-fallback (`resolveRatingPosterUrl`), but for self-hosted art services that key by path segment. The fallback is gated on `{imdb_id}` appearing in the URL path (before `?`), so a composite id like `tmdb:series:123` is only injected where it's a valid path segment and never corrupts a `?imdb_id=` query parameter used by other art providers. When no usable id exists it still returns `null`, preserving the current behaviour of keeping the meta-provided image. It reuses `resolvePattern` rather than duplicating substitution logic.

## Testing

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

Verified the resolver output for the imdb-present, anime (kitsu/tvdb/tmdb only), no-id, and query-param (`?imdb_id=`) cases: anime now resolves to `kitsu:`/`tvdb:`/`tmdb:series:` forms, imdb-present is unchanged, no-id returns null, and query-param patterns are left untouched. Confirmed end to end that the produced URLs return HTTP 200 images from the live art service for kitsu/tvdb/tmdb ids. `node --check` passes. There is no existing test harness around this resolver to extend.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how: used to trace the resolver path and verify the fallback output across id cases and against the live art service; all changes were reviewed and verified.
