### PR TITLE
Fix CRLF line endings in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Cache
+cache
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Cache
-cache
 # Logs
 logs
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh \
       /etc/aiometadata/poster-cache/stats.sh \
       /etc/aiometadata/poster-cache/purge-handler.sh
 
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh
+
 ARG PORT=3232
 EXPOSE ${PORT}
 # Built-in poster cache (opt-in) listens here


### PR DESCRIPTION
Fix CRLF line endings in Dockerfile

## Summary

Fix container startup error '[FATAL tini (6)] exec /usr/local/bin/entrypoint.sh failed: No such file or directory' when building and running the local image.

## Linked issue

Closes #578

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

I tried to build a local Docker image using the Dockerfile. The build completed successfully, but the container failed to start with [FATAL tini (6)] exec /usr/local/bin/entrypoint.sh failed: No such file or directory, which was caused by incorrect line endings in the entrypoint script.

## Testing

1. Built the Docker image locally.
2. Ran the container after applying the line ending fix.
3. Verified that the container starts correctly and no longer fails with [FATAL tini (6)] exec /usr/local/bin/entrypoint.sh failed: No such file or directory.

No additional automated tests were needed, since the change only affects shell script line endings and container startup behavior.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:
