### PR TITLE
movielens: always exclude unreleased movies from explore-catalogs

### DIFF
--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2662,23 +2662,24 @@ async function getMovieLensCatalog(
       : parseInt(process.env.MOVIELENS_CATALOG_TTL_SECONDS || '3600', 10);
     const genreName = genre && genre.toLowerCase() !== 'none' ? genre.toLowerCase() : undefined;
 
+    const isList = catalogId.startsWith('movielens.list.');
+    const isExplore = !isList && catalogId !== 'movielens.watchlist';
+
     const metadata: any = catalogConfig?.metadata || {};
     const sortBy = metadata.sortBy || 'prediction';
     const minYear = metadata.minYear;
     const maxYear = metadata.maxYear;
     const minPop = metadata.minPop ?? (sortBy === 'avgRating' ? 100 : sortBy === 'releaseDate' ? 20 : undefined);
     const maxDaysAgo = metadata.maxDaysAgo;
-    // maxDaysAgo bounds only the past edge; pair it so future titles are excluded.
+    // always exclude unreleased titles from "explore" catalogs.
     const maxFutureDays = metadata.maxFutureDays
-      ?? ((maxDaysAgo || sortBy === 'releaseDate') ? 0 : undefined);
+      ?? (isExplore ? 0 : undefined);
     const sortDirection = metadata.sortDirection;
     const includeRated = metadata.includeRated === true;
     let tag = String(metadata.tags || '')
       .split(',').map((s: string) => s.trim()).filter(Boolean).join(',') || undefined;
 
-    const isList = catalogId.startsWith('movielens.list.');
-
-    if (!tag && !isList && catalogId !== 'movielens.watchlist') {
+    if (!tag && isExplore) {
       const metaTtl = parseInt(
         process.env.MOVIELENS_USERMETA_TTL_SECONDS || process.env.MOVIELENS_GROUPTAGS_TTL_SECONDS || '43200', 10);
       const userMeta: any = await cacheWrapGlobal(`movielens-usermeta:${credId}`,


### PR DESCRIPTION
## Summary

Apply maxFutureDays=0 globally to all "explore" catalogs, to prevent unreleased movies from ever appearing in search and recommendation results.

They were still appearing in several previously unhandled situations, such as "minYear=2026" (which then easily surfaced plenty of future "2029" releases). Instead of trying to catch every scenario (maxDaysAgo, sortBy=releaseDate, minYear=2026, etc), let's just universally exclude them from exploration catalogs.

Unreleased titles cannot be streamed or even be watched in cinemas yet, and they lack meaningful ratings/tags, making them catalog noise.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

See summary.

## Testing

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.