### PR TITLE
movielens: fix caching of API responses

### DIFF
--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -405,7 +405,8 @@ function classifyResult(result: any, error: any = null, cacheKey: string | null 
     cacheKey.includes('mdblist_') ||
     cacheKey.includes('stremthru-') ||
     cacheKey.includes('cinemeta-') ||
-    cacheKey.includes('flixpatrol-')
+    cacheKey.includes('flixpatrol-') ||
+    cacheKey.includes('movielens-')
   );
 
   if (isExternalApi) {

--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2683,7 +2683,7 @@ async function getMovieLensCatalog(
       const metaTtl = parseInt(
         process.env.MOVIELENS_USERMETA_TTL_SECONDS || process.env.MOVIELENS_GROUPTAGS_TTL_SECONDS || '43200', 10);
       const userMeta: any = await cacheWrapGlobal(`movielens-usermeta:${credId}`,
-        () => movielens.getUserMeta(credId), metaTtl);
+        async () => movielens.getUserMeta(credId), metaTtl);
       if (userMeta?.engineId === 'bard' && Array.isArray(userMeta.groupTags) && userMeta.groupTags.length) {
         tag = userMeta.groupTags.map((t: string) => t.trim()).filter(Boolean).join(',');
       }


### PR DESCRIPTION
## Summary

The movielens caches weren't marked as external, which caused the caching backend to reject the usermeta dictionary as if it was an "EMPTY_RESULT" since it couldn't recognize any of its dictionary keys. The catalogs themselves still worked by pure chance (since all of those APIs return arrays, which are a recognized internal cache type).

This meant that MovieLens user metadata was being rejected by the cache and re-fetched every 60 seconds:

"[Global-Cache]  WARN  Caching EMPTY_RESULT result for global:2.8.0:movielens-usermeta:9...b for 60s"

Properly marking all movielens caches as external data fixes the bug.

We also update the usermeta fetching callback to be asynchronous, since the inner `movielens.getUserMeta` function supports it.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

See summary.

## Testing

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.