### PR TITLE
movielens: revert to using standard "edit name" dialog

### DIFF
--- a/configure/src/components/sections/CatalogsSettings.tsx
+++ b/configure/src/components/sections/CatalogsSettings.tsx
@@ -1054,11 +1054,6 @@ const MovieLensSettingsDialog = ({ catalog, isOpen, onClose }: { catalog: Catalo
   const [maxYear, setMaxYear] = useState<string>(catalog.metadata?.maxYear ? String(catalog.metadata.maxYear) : '');
   const [includeRated, setIncludeRated] = useState<boolean>(catalog.metadata?.includeRated === true);
   const [maxDaysAgo, setMaxDaysAgo] = useState<string>(catalog.metadata?.maxDaysAgo ? String(catalog.metadata.maxDaysAgo) : '');
-  const [displayName, setDisplayName] = useState<string>(catalog.name || '');
-
-  useEffect(() => {
-    if (isOpen) setDisplayName(catalog.name || '');
-  }, [isOpen, catalog.name]);
 
   const handleSave = () => {
     const minYearNum = parseInt(minYear, 10);
@@ -1070,7 +1065,6 @@ const MovieLensSettingsDialog = ({ catalog, isOpen, onClose }: { catalog: Catalo
         c.id === catalog.id && c.type === catalog.type
           ? {
               ...c,
-              name: displayName.trim() || c.name,
               cacheTTL: Math.max(cacheTTL, 300),
               metadata: {
                 ...c.metadata,
@@ -1098,11 +1092,6 @@ const MovieLensSettingsDialog = ({ catalog, isOpen, onClose }: { catalog: Catalo
           <DialogTitle>MovieLens Settings</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 py-4">
-          <div className="space-y-2">
-            <Label>Catalog Name</Label>
-            <Input placeholder="e.g. Zombie Picks (Last 2 Years)" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
-            <p className="text-xs text-muted-foreground">Shown as the row title in Stremio.</p>
-          </div>
           {!isWatchlist && (
             <>
               <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary

The movielens edit modal dialog had a "Custom Name" field, but it has proven to be problematic and conflicts with the normal "pen edit" icon next to the catalog name.

Even after the recent fixes which sync the latest name into the modal dialog every time it's re-opened, there's still the reverse bug: Every time the normal "pen edit" is clicked, the normal naming dialog doesn't know about the name changes that were performed via the modal dialog.

Instead of trying to make an invasive two-way sync between the dialogs, it's cleaner to just rely on the normal "pen edit" naming popup that all other catalogs use. It also saves space in the MovieLens dialog.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

See summary.

## Testing

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.