### PR TITLE
movielens: implement "your rated collection" and improve catalogs

### DIFF
--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2663,7 +2663,7 @@ async function getMovieLensCatalog(
     const genreName = genre && genre.toLowerCase() !== 'none' ? genre.toLowerCase() : undefined;
 
     const isList = catalogId.startsWith('movielens.list.');
-    const isExplore = !isList && catalogId !== 'movielens.watchlist';
+    const isExplore = catalogId.startsWith('movielens.explore');
 
     const metadata: any = catalogConfig?.metadata || {};
     const sortBy = metadata.sortBy || 'prediction';
@@ -2675,7 +2675,9 @@ async function getMovieLensCatalog(
     const maxFutureDays = metadata.maxFutureDays
       ?? (isExplore ? 0 : undefined);
     const sortDirection = metadata.sortDirection;
-    const includeRated = metadata.includeRated === true;
+    // always include rated movies if sorting by "your rating".
+    const onlyIncludeRated = sortBy === 'userRating' || sortBy === 'userRatedDate';
+    const includeRated = onlyIncludeRated || metadata.includeRated === true;
     let tag = String(metadata.tags || '')
       .split(',').map((s: string) => s.trim()).filter(Boolean).join(',') || undefined;
 
@@ -2689,7 +2691,7 @@ async function getMovieLensCatalog(
       }
     }
 
-    const filterKey = `${sortBy}:${sortDirection || ''}:${tag || ''}:${minYear || ''}:${maxYear || ''}:${minPop || ''}:${maxFutureDays ?? ''}:${maxDaysAgo || ''}:${includeRated ? 'r1' : 'r0'}`;
+    const filterKey = `${sortBy}:${sortDirection || ''}:${tag || ''}:${minYear || ''}:${maxYear || ''}:${minPop || ''}:${maxFutureDays ?? ''}:${maxDaysAgo || ''}:${includeRated ? (onlyIncludeRated ? 'r-y' : 'r-a') : 'r-n'}`;
     const cacheKey = `movielens-catalog:${credId}:${catalogId}:${genreName || 'all'}:${filterKey}:${page}:${pageSize}`;
     const items = await cacheWrapGlobal(cacheKey, async () => {
       if (isList) {
@@ -2714,7 +2716,9 @@ async function getMovieLensCatalog(
         return movielens.wishlist(credId, { page, pageSize });
       }
       return movielens.explore(credId, {
-        hasRated: includeRated ? undefined : 'no', sortBy, sortDirection, tag, genre: genreName, minYear, maxYear, minPop, maxFutureDays, maxDaysAgo, page, pageSize,
+        // "yes" = only rated, "no" = exclude rated, undefined = include both (all).
+        hasRated: includeRated ? (onlyIncludeRated ? 'yes' : undefined) : 'no',
+        sortBy, sortDirection, tag, genre: genreName, minYear, maxYear, minPop, maxFutureDays, maxDaysAgo, page, pageSize,
       });
     }, ttl);
     const windowItems = Array.isArray(items) ? items : [];

--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2713,7 +2713,7 @@ async function getMovieLensCatalog(
         return collected.slice(offset, offset + pageSize);
       }
       if (catalogId === 'movielens.watchlist') {
-        return movielens.wishlist(credId, { page, pageSize });
+        return movielens.wishlist(credId, { genre: genreName, page, pageSize });
       }
       return movielens.explore(credId, {
         // "yes" = only rated, "no" = exclude rated, undefined = include both (all).

--- a/addon/lib/getManifest.ts
+++ b/addon/lib/getManifest.ts
@@ -1049,7 +1049,8 @@ async function getManifest(config: any, opts: { tag?: string } = {}): Promise<an
       if (userCatalog.id.startsWith('movielens.')) {
           logger.debug(`Processing MovieLens catalog: ${userCatalog.id}`);
           const catalogType = userCatalog.displayType || userCatalog.type;
-          const genreOptions = userCatalog.id.startsWith('movielens.toppicks') ? MOVIELENS_GENRES : [];
+          const supportsGenres = userCatalog.id.startsWith('movielens.explore');
+          const genreOptions = supportsGenres ? MOVIELENS_GENRES : [];
           const options = userCatalog.showInHome ? genreOptions : ['None', ...genreOptions];
           const extra: any[] = [];
           if (options.length > 0) {

--- a/addon/lib/getManifest.ts
+++ b/addon/lib/getManifest.ts
@@ -1049,7 +1049,7 @@ async function getManifest(config: any, opts: { tag?: string } = {}): Promise<an
       if (userCatalog.id.startsWith('movielens.')) {
           logger.debug(`Processing MovieLens catalog: ${userCatalog.id}`);
           const catalogType = userCatalog.displayType || userCatalog.type;
-          const supportsGenres = userCatalog.id.startsWith('movielens.explore');
+          const supportsGenres = userCatalog.id.startsWith('movielens.explore') || userCatalog.id.startsWith('movielens.watchlist');
           const genreOptions = supportsGenres ? MOVIELENS_GENRES : [];
           const options = userCatalog.showInHome ? genreOptions : ['None', ...genreOptions];
           const extra: any[] = [];

--- a/configure/src/components/dashboard/DashboardOperations.tsx
+++ b/configure/src/components/dashboard/DashboardOperations.tsx
@@ -359,12 +359,12 @@ export function DashboardOperations({ data, loading, activeTab }: { data: any; l
               <p className="text-xs text-muted-foreground">
                 Removes every cached entry whose key contains this value — a meta id
                 (<code>tt0111161</code>, <code>mal:64019</code>) or a catalog id
-                (<code>movielens.toppicks</code>). Preview first to see what matches.
+                (<code>movielens.explore</code>). Preview first to see what matches.
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-2">
               <Input
-                placeholder="tt0111161 or movielens.toppicks"
+                placeholder="tt0111161 or movielens.explore"
                 value={clearToken}
                 onChange={(e) => { setClearToken(e.target.value); setClearPreview(null); }}
                 onKeyDown={(e) => { if (e.key === "Enter") handleClearById(true); }}

--- a/configure/src/components/sections/CatalogsSettings.tsx
+++ b/configure/src/components/sections/CatalogsSettings.tsx
@@ -1038,6 +1038,8 @@ const MOVIELENS_SORT_OPTIONS = [
   { value: 'releaseDate', label: 'Release Date' },
   { value: 'dateAdded', label: 'Date Added' },
   { value: 'title', label: 'Title (A-Z)' },
+  { value: 'userRating', label: 'Your Rating' },
+  { value: 'userRatedDate', label: 'Your Rating Date' },
 ];
 
 const MovieLensSettingsDialog = ({ catalog, isOpen, onClose }: { catalog: CatalogConfig, isOpen: boolean, onClose: () => void }) => {
@@ -2658,7 +2660,7 @@ const SortableCatalogItem = ({ catalog, onEditDiscover, onCustomize, onDuplicate
     (catalog.source === 'tmdb' && (catalog.id === 'tmdb.year' || catalog.id === 'tmdb.language')) ||
     !!(config.apiKeys?.traktTokenId || config.apiKeys?.anilistTokenId || config.apiKeys?.mdblist);
   const isDiscover = catalog.id.includes('.discover.') && !!catalog.metadata?.discover?.formState;
-  const isMovieLensExplore = catalog.source === 'movielens' && catalog.id.startsWith('movielens.toppicks');
+  const isMovieLensExplore = catalog.source === 'movielens' && catalog.id.startsWith('movielens.explore');
   const canDuplicate = isDiscover || isMovieLensExplore;
   const canDelete = true;
 
@@ -3567,7 +3569,7 @@ function CatalogsSettingsContent({
     const sourcePrefix = SOURCE_PREFIXES[source] ?? 'tmdb.discover';
     const catalogType = catalog.type || 'movie';
     const newId = catalog.source === 'movielens'
-      ? `movielens.toppicks.${sanitizedName}.${uniqueSuffix}`
+      ? `movielens.explore.${sanitizedName}.${uniqueSuffix}`
       : `${sourcePrefix}.${catalogType}.${sanitizedName}.${uniqueSuffix}`;
 
     const newCatalog: CatalogConfig = {

--- a/configure/src/components/sections/MovieLensIntegration.tsx
+++ b/configure/src/components/sections/MovieLensIntegration.tsx
@@ -144,7 +144,7 @@ export function MovieLensIntegration({ isOpen, onClose }: MovieLensIntegrationPr
   };
 
   const addCatalog = (id: string, name: string, metadata?: Record<string, unknown>) => {
-    const isExplore = id.startsWith('movielens.toppicks');
+    const isExplore = id.startsWith('movielens.explore');
     if (!isExplore && config.catalogs.some(c => c.id === id)) {
       toast.info(`${name} is already added.`);
       return;
@@ -249,17 +249,23 @@ export function MovieLensIntegration({ isOpen, onClose }: MovieLensIntegrationPr
                   <CardDescription>Sort and year filters live in each catalog's gear settings.</CardDescription>
                 </CardHeader>
                 <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.toppicks', 'MovieLens Top Picks')}>
+                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.explore.toppicks', 'MovieLens Top Picks')}>
                     <Sparkles className="h-4 w-4 mr-2" /> Top Picks for You <Plus className="h-4 w-4 ml-auto" />
                   </Button>
                   <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.watchlist', 'MovieLens Watchlist')}>
                     <Bookmark className="h-4 w-4 mr-2" /> Your Watchlist <Plus className="h-4 w-4 ml-auto" />
                   </Button>
-                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.toppicks.recent', 'New Releases for You', { maxDaysAgo: 180 })}>
+                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.explore.toppicks.recent', 'New Releases for You', { maxDaysAgo: 180 })}>
                     <CalendarClock className="h-4 w-4 mr-2" /> New Releases for You <Plus className="h-4 w-4 ml-auto" />
                   </Button>
-                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.toppicks.rated', 'Highest Rated by Users', { sortBy: 'avgRating' })}>
+                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.explore.highestrated', 'Highest Rated by Users', { sortBy: 'avgRating' })}>
                     <Star className="h-4 w-4 mr-2" /> Highest Rated by Users <Plus className="h-4 w-4 ml-auto" />
+                  </Button>
+                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.explore.myrated.score', 'Your Rated Collection', { sortBy: 'userRating', includeRated: true })}>
+                    <Star className="h-4 w-4 mr-2" /> Your Rated Collection <Plus className="h-4 w-4 ml-auto" />
+                  </Button>
+                  <Button variant="outline" className="justify-start" onClick={() => addCatalog('movielens.explore.myrated.date', 'Your Rated Collection by Date', { sortBy: 'userRatedDate', includeRated: true })}>
+                    <Star className="h-4 w-4 mr-2" /> Your Rated Collection by Date <Plus className="h-4 w-4 ml-auto" />
                   </Button>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary

**feat(movielens): implement "your rated collection" and refactor**

Added two new catalogs and their associated sort modes:

- "Your Rated Collection": Your rated movies sorted by the rating you gave them. Backed by the new "Your Rating" sort mode.

- "Your Rated Collection by Date": Your rated movies sorted by when you rated them, regardless of score. Backed by the new "Your Rating Date" sort mode.

Supports genre filtering, which is useful for filtering in your streaming app to see "your top rated science fiction", "your top rated comedy", etc, without having to create separate catalogs.

When sorting by any of the "Your Rating" modes, we internally force-enable "includeRated" and send the special "hasRated=yes" flag which improves the API response's pagination (it will accurately return exactly how many pages there are).

New cache key is used to distinguish the tri-state "hasRated" API parameter: "r-y" (only include rated), "r-n" (don't include rated), "r-a" (include all (both)).

All MovieLens "explore"-API based catalogs have also been renamed to use "movielens.explore" as their prefix, to ensure that all explore-based catalogs work identically and all support the same filtering features, catalog duplication, etc. It's also a more intuitive name, since the previous "movielens.toppicks" prefix is actually a subset of all the things that "explore" can do.

**feat(movielens): support genre filtering in watchlist catalog**

The watchlist internally uses the "explore" API, and therefore supports genre filtering.

This change allows users to filter their watchlist by genre in their streaming apps, which makes it easier to navigate to something they're interested in watching.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

I made the decision to rename the existing catalog IDs during the refactor, marking them as `movielens.explore` when they're based on that API, to have a long future of clean and sane code without any hidden traps or gotchas. It's only been out for developer testing for ~48 hours, and community users haven't gotten started with MovieLens integration yet (it's most likely just you, me and Din), so it's better to nip the naming pattern in the bud now than to allow it to grow into a trap later.

By having the `movielens.explore` prefix, it becomes trivial to identify all catalogs based on the Explore API (the catalogs that should allow duplication + deep, configurable per-catalog settings).

## Testing

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.