### PR TITLE
fix: cache empty movielens list pages

### DIFF
--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -1410,7 +1410,7 @@ async function cacheWrapCatalog(userUUID: string, catalogKey: string, method: ()
       },
     };
   }
-  if (idOnly.startsWith('movielens.') && !idOnly.startsWith('movielens.list.')) {
+  if (idOnly.startsWith('movielens.')) {
     options = { ...options, resultClassifier: classifyResultAllowEmpty };
   }
   const existingOnHit = options.onHit;

--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2720,7 +2720,7 @@ async function getMovieLensCatalog(
         hasRated: includeRated ? (onlyIncludeRated ? 'yes' : undefined) : 'no',
         sortBy, sortDirection, tag, genre: genreName, minYear, maxYear, minPop, maxFutureDays, maxDaysAgo, page, pageSize,
       });
-    }, ttl, isList ? {} : { resultClassifier: classifyResultAllowEmpty });
+    }, ttl, { resultClassifier: classifyResultAllowEmpty });
     const windowItems = Array.isArray(items) ? items : [];
 
     const mdblistShaped = windowItems

--- a/addon/lib/movielens.ts
+++ b/addon/lib/movielens.ts
@@ -155,6 +155,7 @@ interface MovieLensUserMeta {
 async function getUserMeta(credId: string): Promise<MovieLensUserMeta> {
   const empty: MovieLensUserMeta = { groupTags: [], engineId: null, engineWeight: null, popWeight: null, numRatings: null };
   const res = await apiFetch(credId, 'users/me');
+  // return empty metadata on failure, to avoid breaking otherwise working catalogs.
   if (res.status !== 200) return empty;
   const json: any = await res.json();
   const prefs = json?.data?.preferences || {};


### PR DESCRIPTION
(Feel free to close this PR if you disagree with the reasoning! :)

## Summary

Reduces unnecessary backend load by ensuring empty MovieLens list responses respect the standard TTL. Uncached empty pages were causing short lists to trigger API calls every 60 seconds during catalog traversals. Grouping the final empty page into the main cache unit keeps short list reads fast and cached.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

See summary.

## Testing

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.