### PR TITLE
feat: add TVDB fallback IDs and DVD season overrides with updated UI

### DIFF
--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -1041,7 +1041,24 @@ class ConfigApi {
             config.posterRatingProvider = 'none';
           }
         }
-
+        // --- TVDB Configuration Sanitization ---
+        if (Array.isArray(config.tvdbFallbackIds)) {
+          config.tvdbFallbackIds = config.tvdbFallbackIds
+            .filter(id => id != null)
+            .map(id => String(id).trim())
+            .filter(Boolean);
+        } else if (typeof config.tvdbFallbackIds === 'string') {
+          config.tvdbFallbackIds = config.tvdbFallbackIds
+            .split(',')
+            .map(id => id.trim())
+            .filter(Boolean);
+        } else {
+          config.tvdbFallbackIds = [];
+        }
+        // Default to DVD season ordering for older configurations that don't yet define the season type.
+        if (!config.tvdbSeasonTypeFallback) {
+          config.tvdbSeasonTypeFallback = 'dvd';
+        }
         // Strip instance-specific fields that shouldn't be returned from saved config
         const sanitizedConfig = {
           ...config,

--- a/addon/lib/tvdb.ts
+++ b/addon/lib/tvdb.ts
@@ -803,23 +803,34 @@ async function _fetchEpisodesBySeasonType(tvdbId: string, seasonType: string, la
 }
 
 async function getSeriesEpisodes(tvdbId: string, language: string = 'en-US', seasonType: string = 'default', config: UserConfig = {} as UserConfig, bypassCache: boolean = false): Promise<TvdbEpisodesResponse | null> {
-  const cacheKey = `series-episodes:${tvdbId}:${language}:${seasonType}`;
+  let effectiveSeasonType = config.tvdbSeasonType || seasonType || 'default';
+  if (tvdbId && Array.isArray(config.tvdbFallbackIds)) {
+    const cleanTvdbId = String(tvdbId).trim();
+    const isFallbackMatch = config.tvdbFallbackIds.some(
+      (id) => String(id).trim() === cleanTvdbId
+    );
+
+    if (isFallbackMatch && config.tvdbSeasonTypeFallback) {
+      effectiveSeasonType = config.tvdbSeasonTypeFallback;
+    }
+  }
+
+  const cacheKey = `series-episodes:${tvdbId}:${language}:${effectiveSeasonType}`;
 
   return cacheWrapTvdbApi(cacheKey, async () => {
     const consola = require('consola');
-    consola.debug(`[TVDB] Fetching episodes for ${tvdbId} with type: '${seasonType}' and lang: '${language}'`);
-    let result = await _fetchEpisodesBySeasonType(tvdbId, seasonType, language, config);
- 
-    if ((!result || result.episodes.length === 0) && seasonType !== 'official') {
-      logger.debug(`No episodes found for type '${seasonType}'. Falling back to 'official' order.`);
+    consola.debug(`[TVDB] Fetching episodes for ${tvdbId} with type: '${effectiveSeasonType}' and lang: '${language}'`);
+    let result = await _fetchEpisodesBySeasonType(tvdbId, effectiveSeasonType, language, config);
+
+    if ((!result || result.episodes.length === 0) && effectiveSeasonType !== 'official') {
+      logger.debug(`No episodes found for type '${effectiveSeasonType}'. Falling back to 'official' order.`);
       result = await _fetchEpisodesBySeasonType(tvdbId, 'official', language, config);
     }
 
     if ((!result || result.episodes.length === 0) && language !== 'en-US') {
       logger.debug(`No episodes found in '${language}'. Falling back to 'en-US'.`);
-      return getSeriesEpisodes(tvdbId, 'en-US', seasonType, config, true); 
+      return getSeriesEpisodes(tvdbId, 'en-US', effectiveSeasonType, config, true); 
     }
-    
     return normalizeTvdbSeriesEpisodesForCache(result);
   });
 }

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -67,6 +67,8 @@ export interface UserConfig {
   regexExclusionFilter?: string;
   exclusionGenres?: string;
   tvdbSeasonType?: string;
+  tvdbSeasonTypeFallback?: string;
+  tvdbFallbackIds?: string[];
   castCount?: number;
   blurThumbs?: boolean;
   displayAgeRating?: boolean;

--- a/configure/src/components/sections/ProvidersSettings.tsx
+++ b/configure/src/components/sections/ProvidersSettings.tsx
@@ -3,6 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useConfig } from '@/contexts/ConfigContext';
 import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
 
 const movieProviders = [
   { value: 'tmdb', label: 'The Movie Database (TMDB)' },
@@ -177,29 +178,72 @@ export function ProvidersSettings() {
         </Card>
       </div>
 
-
-
       {/* TVDB Specific Settings */}
-      <Card className={!hasTvdbKey ? 'opacity-50' : ''}>
-        <CardHeader>
-          <CardTitle>TheTVDB Settings</CardTitle>
-          <CardDescription>
-            {hasTvdbKey 
-              ? 'Customize how episode data is fetched from TheTVDB.'
-              : 'Add your TVDB API key in the Integrations tab to enable these settings.'}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="max-w-lg">
-            <Label className="text-lg font-medium">Season Order</Label>
-            <Select value={config.tvdbSeasonType} onValueChange={handleSeasonTypeChange} disabled={!hasTvdbKey}>
-              <SelectTrigger className="mt-2"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {tvdbSeasonTypes.map(s => <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>)}
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground mt-2">"Aired Order (Default)" or "Official order" are recommended.</p>
-        </CardContent>
-      </Card>
+          <Card className={!hasTvdbKey ? 'opacity-50' : ''}>
+            <CardHeader>
+              <CardTitle>TheTVDB Settings</CardTitle>
+              <CardDescription>
+                {hasTvdbKey 
+                  ? 'Customize how episode data is fetched from TheTVDB.'
+                  : 'Add your TVDB API key in the Integrations tab to enable these settings.'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Side-by-side Season Orders */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-sm font-medium">Season Order</Label>
+                  <Select 
+                    value={config.tvdbSeasonType || 'default'} 
+                    onValueChange={handleSeasonTypeChange} 
+                    disabled={!hasTvdbKey}
+                  >
+                    <SelectTrigger className="mt-2"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {tvdbSeasonTypes.map(s => <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground mt-2 font-normal">
+                    "Aired Order (Default)" or "Official order" are recommended.
+                  </p>
+                </div>
+
+                <div>
+                  <Label className="text-sm font-medium">Fallback Season Order</Label>
+                  <Select 
+                    value={config.tvdbSeasonTypeFallback || 'dvd'} 
+                    onValueChange={(val) => setConfig(prev => ({ ...prev, tvdbSeasonTypeFallback: val }))}
+                    disabled={!hasTvdbKey}
+                  >
+                    <SelectTrigger className="mt-2">
+                      <SelectValue placeholder="Select fallback order" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {tvdbSeasonTypes.map(s => <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground mt-2 font-normal">
+                    The alternate order for the TVDB IDs listed below.
+                  </p>
+                </div>
+              </div>
+
+              {/* Fallback IDs Input */}
+              <div className="border-t border-white/[0.06] pt-4">
+                <Label className="text-sm font-medium">TVDB Fallback IDs</Label>
+                <Input
+                  className="mt-2"
+                  placeholder="e.g., 366263, 81342"
+                  value={Array.isArray(config.tvdbFallbackIds) ? config.tvdbFallbackIds.join(', ') : (config.tvdbFallbackIds || '')}
+                  onChange={(e) => setConfig(prev => ({ ...prev, tvdbFallbackIds: e.target.value }))}
+                  disabled={!hasTvdbKey}
+                />
+                <p className="text-xs text-muted-foreground mt-2 font-normal">
+                  Comma-separated TVDB IDs (shows) that should ignore the default order and use the fallback order above.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
 
       {/* TMDB Specific Settings */}
       <Card>


### PR DESCRIPTION
## Summary

Some series on TheTVDB require a different season order (such as DVD or Absolute) than the global default to display correctly in Stremio. This PR adds support for per-series TVDB season order overrides by allowing users to configure a fallback season order and a comma-separated list of TVDB series IDs that should use it. Existing behavior remains unchanged unless a series is explicitly configured.

## Linked issue

Closes #607

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

The existing global TVDB season order remains as it is, minimizing changes for existing users while providing a simple way to handle exceptions for specific series. The implementation determines the effective season order before requesting episode data, preserving the existing caching and fallback behavior without introducing additional complexity. The frontend groups the primary and fallback season order settings together and provides a dedicated field for configuring the affected TVDB IDs.

## Testing

Tested in a local development environment using Docker (`compose.dev.yaml`) with Redis.

Verified:
- The frontend builds successfully.
- The new TVDB settings UI renders correctly on desktop and mobile.
- Configuration updates correctly through the UI.
- Series listed in the fallback IDs use the configured fallback season order.
- Series not listed continue using the global season order.
- Metadata loads correctly in Stremio using a generated configuration (verified with *Ascendance of a Bookworm*).
- Existing configurations correctly default `tvdbSeasonTypeFallback` to `dvd` and normalize `tvdbFallbackIds`.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:

I used an AI assistant to help troubleshoot a React state bug with the fallback IDs text input, and to help structure the side-by-side Tailwind CSS grid layout for the UI component. All code changes were implemented, tested, and verified by me before submission.