### PR TITLE
Remove duplicate cache health route

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -5771,25 +5771,6 @@ addon.post('/api/cache/clean-bad', async (req, res) => {
   }
 });
 
-// Get cache health statistics
-addon.get('/api/cache/health', async (req, res) => {
-  try {
-    const { getCacheHealth } = require('./lib/getCache');
-    const health = getCacheHealth();
-    
-    res.json({
-      success: true,
-      health: health
-    });
-  } catch (error) {
-    consola.error('[Cache Health] Error:', error);
-    res.status(500).json({ 
-      error: 'Failed to get cache health',
-      details: error.message 
-    });
-  }
-});
-
 // Test granular caching
 addon.post('/api/cache/test-granular', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary

The server registers `GET /api/cache/health` twice. Because the first handler completes the response without calling `next()`, the second registration is unreachable dead code.

This removes only the duplicate handler while retaining the existing implementation and its `ADMIN_KEY` protection.

## Linked issue

Related downstream issue: https://github.com/JigSawFr/aiometadata-docker/issues/4

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

Removing the unreachable handler is the smallest safe correction. It avoids changing the route's authentication policy or observable behavior while eliminating conflicting implementations.

## Testing

I inspected the resulting diff and verified that only one `GET /api/cache/health` registration remains. The surviving handler and its `ADMIN_KEY` validation are unchanged.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:

AI assistance was used to investigate the duplicate route and prepare the narrowly scoped change and PR description. I personally reviewed the diff and verified that the surviving authenticated handler remains unchanged.
