### PR TITLE
fix(movielens): resolve conflict between maxYear and maxFutureDays

### DIFF
--- a/addon/lib/getCatalog.ts
+++ b/addon/lib/getCatalog.ts
@@ -2668,8 +2668,10 @@ async function getMovieLensCatalog(
     const minPop = metadata.minPop ?? (sortBy === 'avgRating' ? 100 : sortBy === 'releaseDate' ? 20 : undefined);
     const maxDaysAgo = metadata.maxDaysAgo;
     // always exclude unreleased titles from "explore" catalogs.
-    const maxFutureDays = metadata.maxFutureDays
-      ?? (isExplore ? 0 : undefined);
+    // but obey API rule: drop maxFutureDays if the user wants maxYear instead.
+    const maxFutureDays = maxYear !== undefined
+      ? undefined
+      : (metadata.maxFutureDays ?? (isExplore ? 0 : undefined));
     const sortDirection = metadata.sortDirection;
     // always include rated movies if sorting by "your rating".
     const onlyIncludeRated = sortBy === 'userRating' || sortBy === 'userRatedDate';


### PR DESCRIPTION
## Summary

When `maxYear` and `maxFutureDays` were both provided in the query payload, the backend API prioritized `maxFutureDays` and ignored `maxYear` entirely. This caused catalog filters targeting specific release years to fail silently.

To fix this, `maxFutureDays` is now explicitly set to `undefined` whenever `maxYear` is present, ensuring that year-based bounds are properly enforced by the API.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

See summary.

Describe exactly how you tested this change.

- [x] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [ ] No tests were needed, and I explained why.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [x] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.
