### PR TITLE
fix(ci): tag release images with the semver version

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,12 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to tag the image with (e.g. 2.13.0). Leave empty to use the latest release tag.'
+        required: false
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -21,6 +27,29 @@ jobs:
       packages: write
 
     steps:
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)"
+          fi
+          VERSION="${VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "error: could not resolve a semver version (got '$VERSION')" >&2
+            exit 1
+          fi
+          MAJOR="${VERSION%%.*}"
+          MINOR="$(echo "$VERSION" | cut -d. -f2)"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "MAJOR=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "MINOR=$MINOR" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -45,9 +74,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+            type=raw,value=${{ steps.version.outputs.MAJOR }}.${{ steps.version.outputs.MINOR }}
+            type=raw,value=${{ steps.version.outputs.MAJOR }}
             type=raw,value=latest
 
       - name: Build and push multi-platform image
@@ -60,4 +89,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-


### PR DESCRIPTION
## Summary

The release image only ever gets the `latest` tag: every build is a manual `workflow_dispatch` on `dev`, where `docker/metadata-action`'s `type=semver` rules find no tag ref and produce nothing. The `release: published` / `push: tags` auto-triggers have never fired (release-please creates the tag via the API, so no matching push event reaches the workflow), so the semver image tags were never generated. This makes the workflow resolve the version explicitly and tag the image `X.Y.Z` / `X.Y` / `X` / `latest`.

## Linked issue

Required for all non-trivial code changes.

Closes #666

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [x] CI / tooling

## Why this approach

`workflow_dispatch` only reads the workflow from the default branch, and a branch ref carries no semver — so the existing `type=semver` rules can never fire on a manual build. Adding a `version` input and resolving it explicitly (input > release tag > git tag > latest release) makes the semver tags work for every trigger path. `latest` is still pushed on every build so nothing that already pulls `latest` breaks.

## Testing

Verified on the `pixeye33` fork: dispatched with `version=2.13.0` and confirmed `ghcr.io/pixeye33/aiometadata` now carries `latest`, `2.13.0`, `2.13` and `2` after a successful multi-arch build. The `latest` tag is still produced alongside the semver tags.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how: implementation drafted with AI assistance, then verified by running the workflow on a fork and inspecting the resulting image tags.