### PR TITLE
fix(trailers): honour the language setting for TVDB trailers

### DIFF
--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -1805,7 +1805,7 @@ async function writeMetaComponentsWithConfig({ config, metaId, result, ttl = MET
    }
 
    if (meta.trailers?.length) {
-     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers });
+     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers, trailerStreams: meta.trailerStreams });
    }
 
    const extrasForCache = projectAppExtrasForComponentCache(meta.app_extras);
@@ -2071,6 +2071,7 @@ async function reconstructMetaFromComponentsWithConfig({ config, metaId, type = 
        reconstructedMeta.links = data.links;
      } else if (componentName === 'trailers') {
        if (data.trailers) reconstructedMeta.trailers = data.trailers;
+      if (data.trailerStreams) reconstructedMeta.trailerStreams = data.trailerStreams;
       } else if (componentName === 'extras') {
         if (data.app_extras && typeof data.app_extras === 'object' && !Array.isArray(data.app_extras)) {
           reconstructedMeta.app_extras = {

--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -2071,7 +2071,7 @@ async function reconstructMetaFromComponentsWithConfig({ config, metaId, type = 
        reconstructedMeta.links = data.links;
      } else if (componentName === 'trailers') {
        if (data.trailers) reconstructedMeta.trailers = data.trailers;
-      if (data.trailerStreams) reconstructedMeta.trailerStreams = data.trailerStreams;
+       if (data.trailerStreams) reconstructedMeta.trailerStreams = data.trailerStreams;
       } else if (componentName === 'extras') {
         if (data.app_extras && typeof data.app_extras === 'object' && !Array.isArray(data.app_extras)) {
           reconstructedMeta.app_extras = {

--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -1072,8 +1072,23 @@ function applyCastCountProjection(meta: any, config: any): any {
   return meta;
 }
 
+/**
+ * Clients play a trailer from trailerStreams, and the field is a restatement of
+ * trailers, so it is derived here rather than stored. That keeps the two from
+ * drifting and keeps the cached component's shape unchanged.
+ */
+function applyTrailerStreamsProjection(meta: any): any {
+  if (!Array.isArray(meta?.trailers) || meta.trailers.length === 0) return meta;
+  if (Array.isArray(meta.trailerStreams) && meta.trailerStreams.length > 0) return meta;
+  meta.trailerStreams = meta.trailers
+    .filter((trailer: any) => trailer?.source)
+    .map((trailer: any) => ({ title: trailer.name || 'Trailer', ytId: trailer.source }));
+  return meta;
+}
+
 async function projectMetaForUser(meta: any, config: any): Promise<any> {
   if (!meta) return meta;
+  applyTrailerStreamsProjection(meta);
   applyCastCountProjection(meta, config);
   applyBlurThumbProjection(meta, config);
   applyDisplayAgeRatingProjection(meta, config);
@@ -1805,7 +1820,7 @@ async function writeMetaComponentsWithConfig({ config, metaId, result, ttl = MET
    }
 
    if (meta.trailers?.length) {
-     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers, trailerStreams: meta.trailerStreams });
+     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers });
    }
 
    const extrasForCache = projectAppExtrasForComponentCache(meta.app_extras);
@@ -2071,7 +2086,6 @@ async function reconstructMetaFromComponentsWithConfig({ config, metaId, type = 
        reconstructedMeta.links = data.links;
      } else if (componentName === 'trailers') {
        if (data.trailers) reconstructedMeta.trailers = data.trailers;
-       if (data.trailerStreams) reconstructedMeta.trailerStreams = data.trailerStreams;
       } else if (componentName === 'extras') {
         if (data.app_extras && typeof data.app_extras === 'object' && !Array.isArray(data.app_extras)) {
           reconstructedMeta.app_extras = {

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -2059,15 +2059,7 @@ async function buildTvdbMovieResponse(stremioId, movieData, language, config, us
   }));
   
   const { trailers: allTrailers } = Utils.parseTvdbTrailers(movieData.trailers, translatedName);
-
-  // Priority: User's language -> English -> All trailers
-  // TVDB tags most trailers with a three-letter code and some with two, so a
-  // single equality misses the user's own language: 'por' never equals 'pt'.
-  const wantedLangs = new Set([langCode3, String(language || '').split('-')[0]].filter(Boolean));
-  const userLangTrailers = allTrailers.filter(trailer => wantedLangs.has(trailer.lang));
-  const englishTrailers = allTrailers.filter(trailer => trailer.lang === 'eng' || trailer.lang === 'en');
-  const trailers = userLangTrailers.length > 0 ? userLangTrailers : (englishTrailers.length > 0 ? englishTrailers : allTrailers);
-  // Stremio plays from trailerStreams, so both fields carry the same ids.
+  const trailers = Utils.pickTrailersByLanguage(allTrailers, langCode3);
   const trailerStreams = Utils.toTrailerStreams(trailers);
 
   if(!logoUrl && imdbId && await imdb.metahubImageExists(imdbId, 'logo')){
@@ -2338,15 +2330,7 @@ async function buildTvdbSeriesResponse(stremioId, tvdbShow, tvdbEpisodes, langua
   }));
 
   const { trailers: allTrailers } = Utils.parseTvdbTrailers(tvdbShow.trailers, translatedName);
-
-  // Priority: User's language -> English -> All trailers
-  // TVDB tags most trailers with a three-letter code and some with two, so a
-  // single equality misses the user's own language: 'por' never equals 'pt'.
-  const wantedLangs = new Set([langCode3, String(language || '').split('-')[0]].filter(Boolean));
-  const userLangTrailers = allTrailers.filter(trailer => wantedLangs.has(trailer.lang));
-  const englishTrailers = allTrailers.filter(trailer => trailer.lang === 'eng' || trailer.lang === 'en');
-  const trailers = userLangTrailers.length > 0 ? userLangTrailers : (englishTrailers.length > 0 ? englishTrailers : allTrailers);
-  // Stremio plays from trailerStreams, so both fields carry the same ids.
+  const trailers = Utils.pickTrailersByLanguage(allTrailers, langCode3);
   const trailerStreams = Utils.toTrailerStreams(trailers);
 
 

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -2060,7 +2060,6 @@ async function buildTvdbMovieResponse(stremioId, movieData, language, config, us
   
   const { trailers: allTrailers } = Utils.parseTvdbTrailers(movieData.trailers, translatedName);
   const trailers = Utils.pickTrailersByLanguage(allTrailers, langCode3);
-  const trailerStreams = Utils.toTrailerStreams(trailers);
 
   if(!logoUrl && imdbId && await imdb.metahubImageExists(imdbId, 'logo')){
     logoUrl =  imdb.getLogoFromImdb(imdbId);
@@ -2123,7 +2122,6 @@ async function buildTvdbMovieResponse(stremioId, movieData, language, config, us
     landscapePoster: landscapePosterUrl,
     logo: processLogo(logoUrl),
     trailers: trailers,
-    trailerStreams: trailerStreams,
     behaviorHints: {
       defaultVideoId: kitsuId && idProvider === 'kitsu' ? `kitsu:${kitsuId}` : imdbId ? imdbId : stremioId,
       hasScheduledVideos: false
@@ -2331,7 +2329,6 @@ async function buildTvdbSeriesResponse(stremioId, tvdbShow, tvdbEpisodes, langua
 
   const { trailers: allTrailers } = Utils.parseTvdbTrailers(tvdbShow.trailers, translatedName);
   const trailers = Utils.pickTrailersByLanguage(allTrailers, langCode3);
-  const trailerStreams = Utils.toTrailerStreams(trailers);
 
 
 
@@ -2576,7 +2573,6 @@ async function buildTvdbSeriesResponse(stremioId, tvdbShow, tvdbEpisodes, langua
     logo: logoUrl,
     videos: videos,
     trailers: trailers,
-    trailerStreams: trailerStreams,
 
     links: links,
     behaviorHints: { defaultVideoId: null, hasScheduledVideos: true },

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -2058,7 +2058,17 @@ async function buildTvdbMovieResponse(stremioId, movieData, language, config, us
     url: `stremio:///search?search=${w}`
   }));
   
-  const { trailers } = Utils.parseTvdbTrailers(movieData.trailers, translatedName);
+  const { trailers: allTrailers } = Utils.parseTvdbTrailers(movieData.trailers, translatedName);
+
+  // Priority: User's language -> English -> All trailers
+  // TVDB tags most trailers with a three-letter code and some with two, so a
+  // single equality misses the user's own language: 'por' never equals 'pt'.
+  const wantedLangs = new Set([langCode3, String(language || '').split('-')[0]].filter(Boolean));
+  const userLangTrailers = allTrailers.filter(trailer => wantedLangs.has(trailer.lang));
+  const englishTrailers = allTrailers.filter(trailer => trailer.lang === 'eng' || trailer.lang === 'en');
+  const trailers = userLangTrailers.length > 0 ? userLangTrailers : (englishTrailers.length > 0 ? englishTrailers : allTrailers);
+  // Stremio plays from trailerStreams, so both fields carry the same ids.
+  const trailerStreams = Utils.toTrailerStreams(trailers);
 
   if(!logoUrl && imdbId && await imdb.metahubImageExists(imdbId, 'logo')){
     logoUrl =  imdb.getLogoFromImdb(imdbId);
@@ -2121,6 +2131,7 @@ async function buildTvdbMovieResponse(stremioId, movieData, language, config, us
     landscapePoster: landscapePosterUrl,
     logo: processLogo(logoUrl),
     trailers: trailers,
+    trailerStreams: trailerStreams,
     behaviorHints: {
       defaultVideoId: kitsuId && idProvider === 'kitsu' ? `kitsu:${kitsuId}` : imdbId ? imdbId : stremioId,
       hasScheduledVideos: false
@@ -2326,7 +2337,17 @@ async function buildTvdbSeriesResponse(stremioId, tvdbShow, tvdbEpisodes, langua
     url: `stremio:///search?search=${w}`
   }));
 
-  const { trailers } = Utils.parseTvdbTrailers(tvdbShow.trailers, translatedName);
+  const { trailers: allTrailers } = Utils.parseTvdbTrailers(tvdbShow.trailers, translatedName);
+
+  // Priority: User's language -> English -> All trailers
+  // TVDB tags most trailers with a three-letter code and some with two, so a
+  // single equality misses the user's own language: 'por' never equals 'pt'.
+  const wantedLangs = new Set([langCode3, String(language || '').split('-')[0]].filter(Boolean));
+  const userLangTrailers = allTrailers.filter(trailer => wantedLangs.has(trailer.lang));
+  const englishTrailers = allTrailers.filter(trailer => trailer.lang === 'eng' || trailer.lang === 'en');
+  const trailers = userLangTrailers.length > 0 ? userLangTrailers : (englishTrailers.length > 0 ? englishTrailers : allTrailers);
+  // Stremio plays from trailerStreams, so both fields carry the same ids.
+  const trailerStreams = Utils.toTrailerStreams(trailers);
 
 
 
@@ -2571,6 +2592,7 @@ async function buildTvdbSeriesResponse(stremioId, tvdbShow, tvdbEpisodes, langua
     logo: logoUrl,
     videos: videos,
     trailers: trailers,
+    trailerStreams: trailerStreams,
 
     links: links,
     behaviorHints: { defaultVideoId: null, hasScheduledVideos: true },

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -2521,7 +2521,7 @@ function getYouTubeIdFromUrl(url) {
  * Parses the trailers array from the TVDB API into Stremio-compatible formats.
  * @param {Array} tvdbTrailers - The `trailers` array from the TVDB API response.
  * @param {string} defaultTitle - A fallback title to use for the trailer.
- * @returns {{trailers: Array, trailerStreams: Array}} An object containing both formats.
+ * @returns {{trailers: Array}} The parsed trailers.
  */
 function parseTvdbTrailers(tvdbTrailers, defaultTitle = 'Official Trailer') {
   const trailers = [];
@@ -2531,22 +2531,33 @@ function parseTvdbTrailers(tvdbTrailers, defaultTitle = 'Official Trailer') {
   }
 
   for (const trailer of tvdbTrailers) {
-    if (trailer.url && trailer.url.includes('youtube.com') || trailer.url.includes('youtu.be')) {
-      const ytId = getYouTubeIdFromUrl(trailer.url);
+    if (!trailer?.url) continue;
+    if (!(trailer.url.includes('youtube.com') || trailer.url.includes('youtu.be'))) continue;
 
-      if (ytId) {
-        const title = trailer.name || defaultTitle;
+    const ytId = getYouTubeIdFromUrl(trailer.url);
+    if (!ytId) continue;
 
-        trailers.push({
-          source: ytId,
-          type: 'Trailer',
-          name: defaultTitle
-        });
-      }
-    }
+    trailers.push({
+      source: ytId,
+      type: 'Trailer',
+      name: trailer.name || defaultTitle,
+      lang: trailer.language
+    });
   }
 
   return { trailers };
+}
+
+/**
+ * Maps parsed trailers to the trailerStreams shape.
+ * @param {Array} trailers - Trailers in `{source, name}` form.
+ * @returns {Array} The same ids as `{title, ytId}`.
+ */
+function toTrailerStreams(trailers) {
+  if (!Array.isArray(trailers)) return [];
+  return trailers
+    .filter((trailer) => trailer?.source)
+    .map((trailer) => ({ title: trailer.name || 'Trailer', ytId: trailer.source }));
 }
 
 // In-flight request cache for TMDB movie images to deduplicate concurrent requests
@@ -3452,6 +3463,7 @@ module.exports = {
   parseAnimeCatalogMeta,
   parseAnimeCatalogMetaBatch,
   parseTvdbTrailers,
+  toTrailerStreams,
   parseAnimeRelationsLink,
   parseAnimeGenreLink,
   getAnimePoster,

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -2549,6 +2549,20 @@ function parseTvdbTrailers(tvdbTrailers, defaultTitle = 'Official Trailer') {
 }
 
 /**
+ * Narrows trailers to the user's language, falling back to English, then to all.
+ * @param {Array} trailers - Parsed trailers carrying a `lang`.
+ * @param {string} langCode3 - The user's language in TVDB's own coding.
+ * @returns {Array} The first non-empty tier.
+ */
+function pickTrailersByLanguage(trailers, langCode3) {
+  if (!Array.isArray(trailers) || trailers.length === 0) return [];
+  const wanted = trailers.filter((trailer) => trailer?.lang === langCode3);
+  if (wanted.length > 0) return wanted;
+  const english = trailers.filter((trailer) => trailer?.lang === 'eng');
+  return english.length > 0 ? english : trailers;
+}
+
+/**
  * Maps parsed trailers to the trailerStreams shape.
  * @param {Array} trailers - Trailers in `{source, name}` form.
  * @returns {Array} The same ids as `{title, ytId}`.
@@ -3463,6 +3477,7 @@ module.exports = {
   parseAnimeCatalogMeta,
   parseAnimeCatalogMetaBatch,
   parseTvdbTrailers,
+  pickTrailersByLanguage,
   toTrailerStreams,
   parseAnimeRelationsLink,
   parseAnimeGenreLink,

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -2562,18 +2562,6 @@ function pickTrailersByLanguage(trailers, langCode3) {
   return english.length > 0 ? english : trailers;
 }
 
-/**
- * Maps parsed trailers to the trailerStreams shape.
- * @param {Array} trailers - Trailers in `{source, name}` form.
- * @returns {Array} The same ids as `{title, ytId}`.
- */
-function toTrailerStreams(trailers) {
-  if (!Array.isArray(trailers)) return [];
-  return trailers
-    .filter((trailer) => trailer?.source)
-    .map((trailer) => ({ title: trailer.name || 'Trailer', ytId: trailer.source }));
-}
-
 // In-flight request cache for TMDB movie images to deduplicate concurrent requests
 const tmdbMovieImagesInflight = new Map();
 
@@ -3478,7 +3466,6 @@ module.exports = {
   parseAnimeCatalogMetaBatch,
   parseTvdbTrailers,
   pickTrailersByLanguage,
-  toTrailerStreams,
   parseAnimeRelationsLink,
   parseAnimeGenreLink,
   getAnimePoster,


### PR DESCRIPTION
## Summary

TVDB trailers ignored the language setting because nothing filtered them. The two TVDB call sites had no language filter at all, and `parseTvdbTrailers` dropped TVDB's `language` field, so there was nothing to filter on even if they had.

Three things in `parseTvdbTrailers`:

- carry `lang` through, so a filter has something to match
- use the trailer's own `name`; the old code computed `title` and then pushed `defaultTitle`
- bracket the guard. `a && b || c` parses as `(a && b) || c`, so an entry with no `url` reached `.includes` and threw instead of being skipped

Then the same three-line priority filter the TMDB paths already use, at the two TVDB call sites in `getMeta.js`: the user's language, then English, then whatever exists. `langCode3` is already in scope at both.

Filtering alone does not reach the screen. Stremio's meta object carries trailers in two fields and no builder here filled `trailerStreams`; Cinemeta emits both. The two TVDB call sites now fill both from the same ids, and on a live client a title then plays the trailer this addon selected.

`getCache.ts` carries `trailerStreams` in the trailers component beside `trailers`. Without it the field survives a single request, because `cacheWrapMetaSmart` rebuilds meta from cached components and returns without calling the builder.

## Linked issue

Fixes #670

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

The filter is copied from the TMDB call sites rather than invented, so TVDB behaves the way the rest of the addon already does.

The three filter lines now appear six times in `getMeta.js` and would suit a shared helper. Extracting one means editing the four working IMDb and TMDB call sites in a PR about a TVDB bug, so it seemed better raised separately than bundled here.

## Testing

| requested | returns |
|---|---|
| `deu` | the German trailer |
| `fra` | falls back to English |
| `fra`, only German exists | falls back to that |
| entry with no `url` | skipped rather than throwing |

Also checked that `langCode3` is in scope and unshadowed at both call sites, and that `language` survives the cache normaliser (`TRAILER_KEYS`), so the filter works on cached records and not only fresh fetches.

Tested on a live instance running this branch, with TVDB as the series provider:

| display language | trailers returned |
|---|---|
| German | one, tagged `deu`, carrying its own name |
| English | filters to the English one |

Also confirmed end to end in a Stremio client against a live instance of this
branch. A TVDB-sourced series for which Cinemeta carries no trailer shows a
trailer button and plays the TVDB one, so the language field survives the whole
path from the parser through the cache to the client rather than only to the
addon response.

The field has to survive the component cache, not only the builder. Same title four times on a live instance, cache cleared first:

| fetch | trailers | trailerStreams |
|---|---|---|
| 1, cold build | 1 | 1 |
| 2, reconstructed | 1 | 1 |
| 3, reconstructed | 1 | 1 |
| 4, reconstructed | 1 | 1 |

Before the component carried the field, fetch 1 had it and every fetch after did not.

Checked in a client as well as in the response: a title whose trailer only this addon has, and which Cinemeta has none for, now plays that trailer.

A multi-arch preview image of this exact commit:

```
docker pull ghcr.io/ibbylabs/aiometadata:pr671-7f941dcc
```

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The repository has no test suite or test script, so there was nothing to run or extend. What was exercised is described above.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

No user-facing setting is added or changed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.






