### PR TITLE
feat(trailers): let a user choose where trailers come from

### DIFF
--- a/addon/lib/configApi.js
+++ b/addon/lib/configApi.js
@@ -1078,6 +1078,9 @@ class ConfigApi {
           });
         }
 
+        if (!config.trailerProvider) {
+          config.trailerProvider = 'default';
+        }
         if (!config.posterRatingProvider) {
           const pattern = (config.customPosterUrlPattern || '').trim();
           if (pattern.includes('ratingposterdb.com')) {

--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -1805,7 +1805,7 @@ async function writeMetaComponentsWithConfig({ config, metaId, result, ttl = MET
    }
 
    if (meta.trailers?.length) {
-     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers });
+     queueComponentCache(componentsToCache, componentCacheKeys.trailers, { trailers: meta.trailers, trailerStreams: meta.trailerStreams });
    }
 
    const extrasForCache = projectAppExtrasForComponentCache(meta.app_extras);
@@ -2071,6 +2071,7 @@ async function reconstructMetaFromComponentsWithConfig({ config, metaId, type = 
        reconstructedMeta.links = data.links;
      } else if (componentName === 'trailers') {
        if (data.trailers) reconstructedMeta.trailers = data.trailers;
+      if (data.trailerStreams) reconstructedMeta.trailerStreams = data.trailerStreams;
       } else if (componentName === 'extras') {
         if (data.app_extras && typeof data.app_extras === 'object' && !Array.isArray(data.app_extras)) {
           reconstructedMeta.app_extras = {

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -286,7 +286,7 @@ const host = process.env.HOST_NAME.startsWith('http')
     : `https://${process.env.HOST_NAME}`;
 
 // --- Main Orchestrator ---
-async function getMeta(type, language, stremioId, config = {}, userUUID, includeVideos = true) {
+async function getMetaInner(type, language, stremioId, config = {}, userUUID, includeVideos = true) {
   try {
     // Validate inputs
     if (!stremioId || typeof stremioId !== 'string') {
@@ -3512,6 +3512,39 @@ async function buildKitsuAnimeResponse(stremioId, kitsuData, genres, includeObje
     )
     return null
   }
+}
+
+const { getAddonTrailers, toTrailerStreams } = require('./trailerAddon');
+
+// Trailer source is a user preference rather than a property of whichever
+// metadata provider answered, so it is applied once here instead of in each
+// builder. A failed lookup leaves the provider's own trailers in place.
+async function getMeta(type, language, stremioId, config = {}, userUUID, ...rest) {
+  const meta = await getMetaInner(type, language, stremioId, config, userUUID, ...rest);
+
+  if (!meta?.meta) {
+    return meta;
+  }
+
+  // Every provider fills `trailers` and none fills `trailerStreams`, so it is
+  // derived here rather than at each builder.
+  if (!meta.meta.trailerStreams?.length) {
+    meta.meta.trailerStreams = toTrailerStreams(meta.meta.trailers);
+  }
+
+  if (!config?.trailerAddonUrl || config?.trailerProvider === 'default') {
+    return meta;
+  }
+
+  const id = meta.meta.imdb_id || meta.meta.id;
+  const replacement = await getAddonTrailers(config.trailerAddonUrl, type, id, logger);
+
+  if (replacement) {
+    meta.meta.trailers = replacement.trailers;
+    meta.meta.trailerStreams = replacement.trailerStreams;
+  }
+
+  return meta;
 }
 
 module.exports = { getMeta };

--- a/addon/lib/trailerAddon.js
+++ b/addon/lib/trailerAddon.js
@@ -1,0 +1,51 @@
+const TIMEOUT_MS = 4000;
+
+// A Stremio addon's manifest URL carries its own configuration, so the stream
+// endpoint is derived from it rather than assembled here. Streailer answers a
+// wrongly-shaped config path with 200 and its default language, so a URL built
+// here could ignore the user's setting without failing.
+function toStreamUrl(manifestUrl, type, id) {
+  if (typeof manifestUrl !== 'string' || !manifestUrl.trim()) return null;
+  const trimmed = manifestUrl.trim();
+  if (!trimmed.endsWith('/manifest.json')) return null;
+  return `${trimmed.slice(0, -'manifest.json'.length)}stream/${type}/${encodeURIComponent(id)}.json`;
+}
+
+async function getAddonTrailers(manifestUrl, type, id, logger) {
+  if (!id || (type !== 'movie' && type !== 'series')) return null;
+
+  const url = toStreamUrl(manifestUrl, type, id);
+  if (!url) return null;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) {
+      logger?.debug?.(`[trailerAddon] ${res.status} for ${type} ${id}`);
+      return null;
+    }
+
+    const body = await res.json();
+    const streams = Array.isArray(body?.streams) ? body.streams : [];
+    const withIds = streams.filter((s) => typeof s?.ytId === 'string' && s.ytId.length > 0);
+    if (withIds.length === 0) return null;
+
+    return {
+      trailers: withIds.map((s) => ({ source: s.ytId, type: 'Trailer' })),
+      trailerStreams: withIds.map((s) => ({ title: s.title || 'Trailer', ytId: s.ytId }))
+    };
+  } catch (err) {
+    logger?.debug?.(`[trailerAddon] request failed for ${type} ${id}: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+// Stremio plays from trailerStreams; providers that fill only `trailers` leave it
+// empty and the client takes another addon's trailer instead.
+function toTrailerStreams(trailers) {
+  if (!Array.isArray(trailers)) return [];
+  return trailers
+    .filter((trailer) => trailer?.source)
+    .map((trailer) => ({ title: trailer.name || 'Trailer', ytId: trailer.source }));
+}
+
+module.exports = { getAddonTrailers, toStreamUrl, toTrailerStreams };

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -46,6 +46,10 @@ export interface UserConfig {
     { movie?: boolean; series?: boolean }
   >>;
   /** Poster rating provider: 'rpdb' for RatingPosterDB, 'top' for Top Poster API, or 'custom' for custom URL patterns */
+  /** Trailer source: 'default' uses the metadata provider's trailers, 'custom' takes them from a Stremio addon */
+  trailerProvider?: 'default' | 'streailer' | 'custom';
+  /** Manifest URL of the trailer addon used when trailerProvider is not 'default' */
+  trailerAddonUrl?: string;
   posterRatingProvider?: 'rpdb' | 'top' | 'custom';
   catalogs?: Catalog[];
   streaming?: StreamingConfig[];

--- a/configure/src/components/sections/ProvidersSettings.tsx
+++ b/configure/src/components/sections/ProvidersSettings.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
 import { useConfig } from '@/contexts/ConfigContext';
 import { isInUse } from '@/lib/metaProviderUsage';
 import { Callout } from '@/components/settings/Callout';
@@ -8,6 +9,14 @@ import { ProviderSelect, type SelectableOption } from '@/components/settings/Pro
 import { SettingRow } from '@/components/settings/SettingRow';
 import { NoticeDisclosure } from '@/components/settings/NoticeDisclosure';
 import { animeNotices } from '@/lib/animeNotices';
+
+const STREAILER_CONFIGURE = 'https://streailer.elfhosted.com/configure';
+
+const trailerProviders: SelectableOption[] = [
+  { value: 'default', label: 'Metadata provider (default)' },
+  { value: 'streailer', label: 'Streailer' },
+  { value: 'custom', label: 'Custom addon' },
+];
 
 const movieProviders: SelectableOption[] = [
   { value: 'tmdb', label: 'The Movie Database (TMDB)' },
@@ -48,6 +57,9 @@ const tvdbSeasonTypes: SelectableOption[] = [
 
 export function ProvidersSettings() {
   const { config, setConfig, hasBuiltInTvdb } = useConfig();
+  // A config saved before this field existed has no trailerProvider. Derive it
+  // once so the select and the fields below cannot disagree about what is set.
+  const trailerProvider = config.trailerProvider || 'default';
   const isImdbForCatalog = !!config.mal?.useImdbIdForCatalogAndSearch;
   const hasTvdbKey = !!config.apiKeys?.tvdb?.trim() || hasBuiltInTvdb;
 
@@ -131,6 +143,63 @@ export function ProvidersSettings() {
 
       {/* Provider Selection Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <Card className="mb-6">
+          <CardContent className="pt-6">
+            <SettingRow
+              htmlFor="trailerProvider"
+              label="Trailer Source"
+              description="Use the metadata provider's trailers, or any Stremio trailer addon."
+              control={
+                <ProviderSelect
+                  id="trailerProvider"
+                  ariaLabel="Trailer source"
+                  value={trailerProvider}
+                  onValueChange={(value) => {
+                    const provider = value as 'default' | 'streailer' | 'custom';
+                    if (provider === 'streailer') {
+                      // Deliberately not prefilled. The bare manifest URL returns
+                      // the addon's own default language, so filling it in hands
+                      // the user a working-looking setting they did not choose.
+                      setConfig(prev => ({ ...prev, trailerProvider: provider, trailerAddonUrl: '' }));
+                    } else if (provider === 'default') {
+                      setConfig(prev => ({ ...prev, trailerProvider: provider, trailerAddonUrl: '' }));
+                    } else {
+                      setConfig(prev => ({ ...prev, trailerProvider: provider }));
+                    }
+                  }}
+                  options={trailerProviders}
+                  className="w-full sm:w-[240px]"
+                />
+              }
+            />
+            {trailerProvider !== 'default' && (
+              <SettingRow
+                htmlFor="trailerAddonUrl"
+                label="Trailer Addon URL"
+                description="The addon's manifest URL. An unconfigured URL returns the addon's own default language, so set the language on its configure page and paste the URL it gives you."
+                control={
+                  <Input
+                    id="trailerAddonUrl"
+                    value={config.trailerAddonUrl || ''}
+                    placeholder={STREAILER_CONFIGURE}
+                    onChange={(e) => setConfig(prev => ({ ...prev, trailerAddonUrl: e.target.value }))}
+                    className="w-full sm:w-[420px]"
+                  />
+                }
+              />
+            )}
+            {trailerProvider === 'streailer' && (
+              <p className="text-sm text-muted-foreground mt-2">
+                Pick your language on{' '}
+                <a href={STREAILER_CONFIGURE} target="_blank" rel="noreferrer" className="underline">
+                  Streailer's configure page
+                </a>
+                , then paste the URL it produces above.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
         <Card>
           <CardHeader><CardTitle>Movie Provider</CardTitle><CardDescription>Source for movie data.</CardDescription></CardHeader>
           <CardContent>

--- a/configure/src/contexts/ConfigContext.tsx
+++ b/configure/src/contexts/ConfigContext.tsx
@@ -154,6 +154,8 @@ const initialConfig: AppConfig = {
     openrouter: "",
     publicmetadb: "",
   },
+  trailerProvider: 'default' as 'default' | 'streailer' | 'custom',
+  trailerAddonUrl: '',
   posterRatingProvider: 'none' as 'none' | 'rpdb' | 'top' | 'custom',
   usePosterProxy: true,
   mdblistWatchTracking: false,

--- a/configure/src/contexts/config.ts
+++ b/configure/src/contexts/config.ts
@@ -210,6 +210,9 @@ export interface AppConfig {
     apiKey?: string;
   }>;
   /** Poster rating provider: 'none' to disable rating posters, 'rpdb' for RatingPosterDB, 'top' for Top Poster API, or 'custom' for custom URL patterns */
+  /** Trailer source: 'default' uses the metadata provider's trailers, otherwise a Stremio addon supplies them */
+  trailerProvider?: 'default' | 'streailer' | 'custom';
+  trailerAddonUrl?: string;
   posterRatingProvider?: 'none' | 'rpdb' | 'top' | 'custom';
   usePosterProxy: boolean;
   mdblistWatchTracking: boolean;

--- a/configure/src/lib/settingsSearchIndex.ts
+++ b/configure/src/lib/settingsSearchIndex.ts
@@ -238,6 +238,12 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
 
   // ── Meta Providers — sections/ProvidersSettings.tsx ──
   {
+    id: 'providers.trailerProvider', section: 'providers', anchor: 'trailerProvider',
+    label: 'Trailer Source',
+    description: 'Use the metadata provider\'s trailers, or any Stremio trailer addon.',
+    keywords: ['trailer', 'streailer', 'language'],
+  },
+  {
     id: 'providers.movieProvider', section: 'providers', anchor: 'movie-provider',
     label: 'Movie Provider',
     description: 'Source for movie data.',


### PR DESCRIPTION
## Summary

Lets a user point trailers at any Stremio addon that returns a YouTube id, instead of taking whatever the metadata provider supplies.

```
default     the metadata provider's own trailers, as today
streailer   shows a link to Streailer's configure page
custom      paste any trailer addon's manifest URL
```

`streailer` and `custom` are the same code path; the preset only points at where to get the URL. It deliberately does not prefill one: an unconfigured Streailer URL returns that addon's own default language, so filling it in would hand the user a working-looking setting they never chose.

**If you would rather not name a third-party service in the settings page, delete the `streailer` entry from `trailerProviders`.** The custom option carries the feature without it.

## Linked issue

Closes #669

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

A Stremio addon's manifest URL already carries that addon's own configuration, so its language setting travels with the URL the user pastes. Nothing here builds a config, which matters: Streailer answers a wrongly-shaped config path with 200 and its default language, so a URL assembled by this addon could ignore the setting without ever failing.

Taking a URL rather than a named provider list means the next trailer addon needs no code change. The stream endpoint is derived from the manifest URL by string swap, and a URL not ending in `/manifest.json` is refused rather than guessed at.

Applied once in `getMeta` rather than per builder, since trailer source is a user preference rather than a property of whichever provider answered. A failed or empty lookup leaves the provider's own trailers in place.

The same boundary fills `trailerStreams` for every provider when a builder left it empty. Stremio's meta object carries trailers in two fields and nothing here filled that one; Cinemeta emits both. `getCache.ts` carries the field in the trailers component so it survives a rebuild from cache.

**This changes what existing users see.** Anyone with another metadata addon installed has been getting that addon's trailers for titles this one also has; they will now get these. That is the intent, but it is a behaviour change rather than a new setting they opted into.

Modelled on the existing `posterRatingProvider` for the type declaration, the context default and the search-index entry, and on the movie and series selects in the same file for the `SettingRow` + `ProviderSelect` pair.

## Testing

An addon returns **200 with an empty `streams` array** for a title it does not know, not a 404. That was checked against a live instance, and it is why the guard is on the number of usable ids rather than on `res.ok` — keying on the status alone would replace good trailers with an empty list on every unknown title.

| case | result |
|---|---|
| manifest URL carrying a language | derives the matching stream URL, verified against a live instance |
| plain manifest URL | derives `stream/<type>/<id>.json` |
| URL not ending in `/manifest.json` | refused |
| empty or missing URL | refused |
| unknown title | provider's own trailers left in place |

`tsc --noEmit` is clean across the repo.

Tested on a live instance running this branch: selecting a trailer addon and
pasting its manifest URL returns that addon's trailers, and leaving the setting on
`default` leaves the metadata provider's own trailers untouched.

A multi-arch preview image of this exact commit:

```
docker pull ghcr.io/ibbylabs/aiometadata:pr672-2ee7da53
```

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The repository has no test suite or test script, so there was nothing to run or extend. What was exercised is described above.

## Documentation

- [ ] I updated documentation or comments where needed.
- [x] No documentation updates were needed.

The setting is self-describing in the configure UI, and the addon URL field says where to configure the addon's own language.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.





