### PR TITLE
feat(simkl): add PIN authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,8 +136,13 @@ MDBLIST_API_KEY=
 GEMINI_API_KEY=
 # Your SimKL client ID
 SIMKL_CLIENT_ID=
-# Your SimKL client secret
+# Your SimKL client secret. Only needed for the browser-redirect OAuth flow.
 SIMKL_CLIENT_SECRET=
+# Which SimKL connection flow(s) to offer: oauth, pin, or both.
+# "pin" needs only SIMKL_CLIENT_ID - no client secret and no publicly reachable
+# callback URL - which makes it the right choice for private, self-hosted instances.
+# Default: pin when SIMKL_CLIENT_SECRET is empty, otherwise oauth.
+SIMKL_AUTH_MODE=
 # The redirect URI for SimKL OAuth (must match your SimKL app settings)
 # Example: https://your-domain.com/api/auth/simkl/callback
 SIMKL_REDIRECT_URI=

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -233,7 +233,16 @@ async function deviceAuthPollRateLimitMiddleware(req, res, next) {
 
   try {
     const minuteBucket = Math.floor(Date.now() / 60000);
-    const rateKey = `rate-limit:device-auth-poll:${minuteBucket}`;
+    // Keyed per caller, the way the config-load limiter is. A single bucket for
+    // the whole instance would let a handful of concurrent authorizations spend
+    // the budget, and would let anyone spend it deliberately: a pending code
+    // polls every few seconds and these routes need no session.
+    const target = (typeof req.query?.sessionId === 'string' && req.query.sessionId)
+      || (typeof req.body?.sessionId === 'string' && req.body.sessionId)
+      || req.session?.accountId
+      || req.ip
+      || 'unknown';
+    const rateKey = `rate-limit:device-auth-poll:${target}:${minuteBucket}`;
 
     // Bounded: with no Redis listening, ioredis holds a command for the better
     // part of a minute, and these routes are polled every few seconds. A count
@@ -1303,11 +1312,13 @@ addon.get("/api/auth/simkl/pin/status", deviceAuthPollRateLimitMiddleware, async
     const user = await simklClient.getMe(poll.access_token);
     const tokenId = await persistSimklToken(user, poll.access_token);
 
-    await deleteDeviceAuthSession(sessionId);
-
     if (!tokenId) {
+      // Session left in place: storing the token is the only thing that failed,
+      // so the next poll can try again rather than making the user start over.
       return res.status(500).json({ error: "Simkl authorized the connection, but this server could not store the token." });
     }
+
+    await deleteDeviceAuthSession(sessionId);
 
     consola.info(`[Simkl PIN] Connected user ${user.username} - tokenId: ${tokenId}`);
     res.json({ status: 'authorized', tokenId, username: user.username });

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -64,6 +64,14 @@ const {
 const { renderOAuthPage } = require('./lib/oauthPage');
 const { hasAnyWatchTrackingEnabled } = require('./lib/watchTracking');
 const { SimklClient } = require('./lib/simkl');
+const {
+  createSessionId,
+  deleteDeviceAuthSession,
+  getDeviceAuthSession,
+  registerPoll,
+  saveDeviceAuthSession,
+  widenPollInterval,
+} = require('./lib/deviceAuthSessions');
 const jikan = require('./lib/mal');
 const buildInfo = require('./lib/buildInfo');
 const { clientDistDir, clientIndexPath, publicDir } = require('./lib/runtimePaths');
@@ -80,6 +88,21 @@ const TRAKT_OAUTH_STATE_TTL_MS = parseInt(process.env.TRAKT_OAUTH_STATE_TTL_MS |
 const usedAnilistCodes = new Set();
 const ANILIST_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const SIMKL_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+// Which Simkl flows this instance offers. PIN needs only a client id, so it is
+// the default when no secret is set.
+function resolveSimklAuthMode() {
+  const configured = String(getSetting('SIMKL_AUTH_MODE') || '').trim().toLowerCase();
+  if (configured === 'pin' || configured === 'oauth' || configured === 'both') {
+    return configured;
+  }
+  return getSetting('SIMKL_CLIENT_SECRET') ? 'oauth' : 'pin';
+}
+
+function simklPinEnabled() {
+  const mode = resolveSimklAuthMode();
+  return mode === 'pin' || mode === 'both';
+}
 
 const usedMalCodes = new Set();
 const MAL_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
@@ -158,6 +181,9 @@ addon.use(
     '/api/auth/trakt/callback',
     '/api/auth/simkl/authorize',
     '/api/auth/simkl/callback',
+    '/api/auth/simkl/pin',
+    '/api/auth/simkl/pin/status',
+    '/api/auth/simkl/pin/cancel',
     '/api/auth/movielens/connect',
   ],
   noStoreOAuthHeaders
@@ -186,6 +212,50 @@ async function testKeysRateLimitMiddleware(req, res, next) {
     }
   } catch (error) {
     consola.warn('[Rate Limit] /api/test-keys limiter failed, allowing request:', error.message);
+  }
+
+  next();
+}
+
+const REDIS_LIMITER_TIMEOUT_MS = 500;
+
+function DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN() {
+  const parsed = parseInt(getSetting('DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN'), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240;
+}
+
+// Own bucket: a pending code polls every few seconds and would eat the much
+// tighter /api/test-keys budget.
+async function deviceAuthPollRateLimitMiddleware(req, res, next) {
+  if (!redis) {
+    return next();
+  }
+
+  try {
+    const minuteBucket = Math.floor(Date.now() / 60000);
+    const rateKey = `rate-limit:device-auth-poll:${minuteBucket}`;
+
+    // Bounded: with no Redis listening, ioredis holds a command for the better
+    // part of a minute, and these routes are polled every few seconds. A count
+    // we can't read in time means the request is allowed through.
+    const currentCount = await Promise.race([
+      redis.incr(rateKey),
+      new Promise(resolve => setTimeout(() => resolve(null), REDIS_LIMITER_TIMEOUT_MS).unref()),
+    ]);
+
+    if (currentCount === null) {
+      return next();
+    }
+
+    if (currentCount === 1) {
+      redis.expire(rateKey, 70).catch(() => undefined);
+    }
+
+    if (currentCount > DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN()) {
+      return res.status(429).json({ error: 'Too many authorization status requests. Please try again shortly.' });
+    }
+  } catch (error) {
+    consola.warn('[Rate Limit] Device auth poll limiter failed, allowing request:', error.message);
   }
 
   next();
@@ -505,6 +575,7 @@ const respond = function (req, res, data, opts?) {
       gemini: getSetting('GEMINI_API_KEY'),
       trakt: getSetting('TRAKT_CLIENT_ID'),
       simkl: getSetting('SIMKL_CLIENT_ID'),
+      simklAuthMode: resolveSimklAuthMode(),
       customDescriptionBlurb: getSetting('CUSTOM_DESCRIPTION_BLURB'),
       addonVersion: ADDON_VERSION,
       hasBuiltInTvdb: !!getSetting('BUILT_IN_TVDB_API_KEY'),
@@ -932,6 +1003,54 @@ addon.post("/api/movielens/lists/:userUUID", async (req, res) => {
   }
 });
 
+// Saves a new Simkl access token and returns the token ID the user pastes into
+// their config. Used by both the OAuth callback and the PIN flow.
+async function persistSimklToken(user, accessToken) {
+  // Check if this Simkl user already has a token in the database
+  const existingTokens = await database.getOAuthTokensByProvider('simkl');
+  const existingToken = existingTokens.find(t => t.user_id.toLowerCase() === user.username.toLowerCase());
+
+  let tokenId;
+  let saved;
+
+  if (existingToken) {
+    // Update existing token
+    tokenId = existingToken.id;
+    consola.info(`[Simkl OAuth] Updating existing token - tokenId: ${tokenId}, user: ${user.username}`);
+
+    // Simkl tokens don't expire, so we don't have expires_at
+    saved = await database.updateOAuthToken(tokenId, accessToken, '', 0);
+  } else {
+    // Create new token
+    tokenId = crypto.randomUUID();
+    consola.info(`[Simkl OAuth] Creating new token - tokenId: ${tokenId}, user: ${user.username}`);
+
+    saved = await database.saveOAuthToken(tokenId, 'simkl', user.username, accessToken, '', 0, '');
+  }
+
+  if (!saved) {
+    return null;
+  }
+
+  try {
+    const userSimklTokens = existingTokens.filter(t => t.user_id.toLowerCase() === user.username.toLowerCase());
+    const oldTokenIds = userSimklTokens.map(t => t.id).filter(id => id !== tokenId);
+    if (oldTokenIds.length > 0) {
+      const affectedUsers = await database.getUsersByOAuthTokenIds('simklTokenId', oldTokenIds);
+      for (const dbUser of affectedUsers) {
+        dbUser.config.apiKeys.simklTokenId = tokenId;
+        await database.saveUserConfig(dbUser.id, dbUser.password_hash, dbUser.config);
+        configCache.del(dbUser.id);
+        consola.info(`[Simkl OAuth] Updated user ${dbUser.id} config to use new token ${tokenId}`);
+      }
+    }
+  } catch (configError) {
+    consola.warn(`[Simkl OAuth] Warning: Could not auto-update user configs - ${configError.message}`);
+  }
+
+  return tokenId;
+}
+
 // --- Simkl OAuth Routes ---
 addon.get("/api/auth/simkl/authorize", async (req, res) => {
   try {
@@ -1003,42 +1122,9 @@ addon.get("/api/auth/simkl/callback", async (req, res) => {
     // Get user info
     const user = await simklClient.getMe(tokens.access_token);
     
-    // Check if this Simkl user already has a token in the database
-    const existingTokens = await database.getOAuthTokensByProvider('simkl');
-    const existingToken = existingTokens.find(t => t.user_id.toLowerCase() === user.username.toLowerCase());
+    const tokenId = await persistSimklToken(user, tokens.access_token);
     
-    let tokenId;
-    let saved;
-    
-    if (existingToken) {
-      // Update existing token
-      tokenId = existingToken.id;
-      consola.info(`[Simkl OAuth] Updating existing token - tokenId: ${tokenId}, user: ${user.username}`);
-      
-      // Simkl tokens don't expire, so we don't have expires_at
-      saved = await database.updateOAuthToken(
-        tokenId,
-        tokens.access_token,
-        '', 
-        0 
-      );
-    } else {
-      // Create new token
-      tokenId = crypto.randomUUID();
-      consola.info(`[Simkl OAuth] Creating new token - tokenId: ${tokenId}, user: ${user.username}`);
-      
-      saved = await database.saveOAuthToken(
-        tokenId,
-        'simkl',
-        user.username,
-        tokens.access_token,
-        '', 
-        0, 
-        '' 
-      );
-    }
-    
-    if (!saved) {
+    if (!tokenId) {
       return res.status(500).send(renderOAuthPage({
         provider: 'simkl',
         status: 'error',
@@ -1046,22 +1132,6 @@ addon.get("/api/auth/simkl/callback", async (req, res) => {
         message: 'Simkl authorized the connection, but this server could not store the token. Please try again.',
         retryHref: '/api/auth/simkl/authorize',
       }));
-    }
-    
-    try {
-      const userSimklTokens = existingTokens.filter(t => t.user_id.toLowerCase() === user.username.toLowerCase());
-      const oldTokenIds = userSimklTokens.map(t => t.id).filter(id => id !== tokenId);
-      if (oldTokenIds.length > 0) {
-        const affectedUsers = await database.getUsersByOAuthTokenIds('simklTokenId', oldTokenIds);
-        for (const dbUser of affectedUsers) {
-          dbUser.config.apiKeys.simklTokenId = tokenId;
-          await database.saveUserConfig(dbUser.id, dbUser.password_hash, dbUser.config);
-          configCache.del(dbUser.id);
-          consola.info(`[Simkl OAuth] Updated user ${dbUser.id} config to use new token ${tokenId}`);
-        }
-      }
-    } catch (configError) {
-      consola.warn(`[Simkl OAuth] Warning: Could not auto-update user configs - ${configError.message}`);
     }
 
     res.send(renderOAuthPage({
@@ -1128,6 +1198,127 @@ addon.post("/api/auth/trakt/disconnect", async (req, res) => {
     consola.error("[Trakt] Disconnect error:", error);
     res.status(500).json({ error: "Failed to disconnect Trakt" });
   }
+});
+
+// Drops a pending session so a cancelled code doesn't linger until it expires.
+// Knowing the session id is the only thing needed, same as polling it.
+async function handleDeviceAuthCancel(req, res, provider) {
+  try {
+    const sessionId = typeof req.body?.sessionId === 'string' ? req.body.sessionId : '';
+    const session = await getDeviceAuthSession(sessionId, provider);
+    if (session) {
+      await deleteDeviceAuthSession(sessionId);
+    }
+    res.json({ cancelled: !!session });
+  } catch (error) {
+    consola.error(`[${provider}] Failed to cancel the authorization session:`, error);
+    res.status(500).json({ error: "Failed to cancel the authorization" });
+  }
+}
+
+// --- Simkl PIN (device) Routes ---
+// No client secret and no reachable callback URL needed, so these work on
+// private instances where the OAuth flow can't.
+addon.post("/api/auth/simkl/pin", deviceAuthPollRateLimitMiddleware, async (req, res) => {
+  try {
+    if (!simklPinEnabled()) {
+      return res.status(404).json({ error: "Simkl PIN authentication is not enabled on this instance." });
+    }
+
+    const clientId = getSetting('SIMKL_CLIENT_ID');
+    if (!clientId) {
+      return res.status(500).json({ error: "Simkl is not configured. Please set the SIMKL_CLIENT_ID environment variable." });
+    }
+
+    const simklClient = new SimklClient(clientId);
+    const pin = await simklClient.requestPin();
+
+    const sessionId = createSessionId();
+    const expiresAt = Date.now() + pin.expires_in * 1000;
+    await saveDeviceAuthSession(sessionId, {
+      provider: 'simkl',
+      userCode: pin.user_code,
+      expiresAt,
+      pollIntervalMs: pin.interval * 1000,
+      lastPolledAt: 0,
+    });
+
+    res.json({
+      sessionId,
+      userCode: pin.user_code,
+      verificationUrl: pin.verification_url,
+      interval: pin.interval,
+      expiresIn: pin.expires_in,
+    });
+  } catch (error) {
+    consola.error("[Simkl PIN] Failed to request a PIN:", error);
+    res.status(500).json({ error: "Failed to request a Simkl PIN" });
+  }
+});
+
+addon.get("/api/auth/simkl/pin/status", deviceAuthPollRateLimitMiddleware, async (req, res) => {
+  try {
+    if (!simklPinEnabled()) {
+      return res.status(404).json({ error: "Simkl PIN authentication is not enabled on this instance." });
+    }
+
+    const clientId = getSetting('SIMKL_CLIENT_ID');
+    if (!clientId) {
+      return res.status(500).json({ error: "Simkl is not configured. Please set the SIMKL_CLIENT_ID environment variable." });
+    }
+
+    const sessionIdParam = Array.isArray(req.query.sessionId) ? req.query.sessionId[0] : req.query.sessionId;
+    const sessionId = typeof sessionIdParam === 'string' ? sessionIdParam : '';
+
+    // The session id stays in the browser that started the flow, so guessing the
+    // short user code isn't enough to claim the token.
+    const session = await getDeviceAuthSession(sessionId, 'simkl');
+    if (!session) {
+      return res.status(404).json({ status: 'expired' });
+    }
+
+    // Simkl asks callers to respect the interval it handed out, so polls that
+    // arrive early are answered without bothering it.
+    if (!await registerPoll(sessionId, session)) {
+      return res.json({ status: 'pending' });
+    }
+
+    const simklClient = new SimklClient(clientId);
+    const poll = await simklClient.pollPin(session.userCode);
+
+    if (poll.status === 'pending') {
+      return res.json({ status: 'pending' });
+    }
+
+    if (poll.status === 'slow_down') {
+      await widenPollInterval(sessionId, session);
+      return res.json({ status: 'slow_down' });
+    }
+
+    if (poll.status === 'expired') {
+      await deleteDeviceAuthSession(sessionId);
+      return res.json({ status: 'expired' });
+    }
+
+    const user = await simklClient.getMe(poll.access_token);
+    const tokenId = await persistSimklToken(user, poll.access_token);
+
+    await deleteDeviceAuthSession(sessionId);
+
+    if (!tokenId) {
+      return res.status(500).json({ error: "Simkl authorized the connection, but this server could not store the token." });
+    }
+
+    consola.info(`[Simkl PIN] Connected user ${user.username} - tokenId: ${tokenId}`);
+    res.json({ status: 'authorized', tokenId, username: user.username });
+  } catch (error) {
+    consola.error("[Simkl PIN] Status check failed:", error);
+    res.status(500).json({ error: "Failed to check the Simkl PIN status" });
+  }
+});
+
+addon.post("/api/auth/simkl/pin/cancel", async (req, res) => {
+  await handleDeviceAuthCancel(req, res, 'simkl');
 });
 
 addon.post("/api/auth/simkl/disconnect", async (req, res) => {

--- a/addon/lib/deviceAuthSessions.ts
+++ b/addon/lib/deviceAuthSessions.ts
@@ -91,6 +91,8 @@ export async function getDeviceAuthSession(
     }
   }
 
+  pruneMemorySessions(now);
+
   if (!session || session.provider !== provider) return null;
   if (session.expiresAt <= now) {
     await deleteDeviceAuthSession(sessionId);
@@ -118,13 +120,16 @@ export async function registerPoll(
   return true;
 }
 
+/** Longest gap we back off to, so a repeated slow down cannot stall the flow. */
+const MAX_POLL_INTERVAL_MS = 30000;
+
 /** Backs off after a provider tells us we're polling too fast. */
 export async function widenPollInterval(
   sessionId: string,
   session: DeviceAuthSession,
   now: number = Date.now()
 ): Promise<void> {
-  session.pollIntervalMs += 2000;
+  session.pollIntervalMs = Math.min(session.pollIntervalMs + 2000, MAX_POLL_INTERVAL_MS);
   await saveDeviceAuthSession(sessionId, session, now);
 }
 

--- a/addon/lib/deviceAuthSessions.ts
+++ b/addon/lib/deviceAuthSessions.ts
@@ -1,0 +1,138 @@
+import crypto from 'crypto';
+const consola = require('consola');
+const redis = require('./redisClient');
+
+const logger = consola.withTag('DeviceAuth');
+
+const REDIS_KEY_PREFIX = 'device-auth:session:';
+
+export type DeviceAuthProvider = 'simkl';
+
+export interface DeviceAuthSession {
+  provider: DeviceAuthProvider;
+  userCode: string;
+  expiresAt: number;
+  /** Shortest gap we let the browser poll the provider at. */
+  pollIntervalMs: number;
+  lastPolledAt: number;
+}
+
+// Written to both stores: Redis so other replicas can see the session, memory so
+// things still work when Redis is down, which is the common self-hosted case. A
+// session written while Redis is down is only visible to the process that made
+// it, so on a multi-replica instance the browser has to reach that same process.
+// Sessions are write-once apart from the poll bookkeeping, so the two stores
+// can't disagree, they can only be missing.
+//
+// Redis writes are not awaited. With no server listening, ioredis sits on a
+// command for the better part of a minute before giving up, which would stall
+// every poll. Memory is updated first, so the request never waits on Redis.
+const memorySessions = new Map<string, DeviceAuthSession>();
+
+function pruneMemorySessions(now: number): void {
+  for (const [id, session] of memorySessions) {
+    if (session.expiresAt <= now) memorySessions.delete(id);
+  }
+}
+
+/** Caps how long a lookup waits on Redis before treating it as a miss. */
+const REDIS_READ_TIMEOUT_MS = 1000;
+
+function withTimeout<T>(work: Promise<T>, ms: number): Promise<T | null> {
+  return Promise.race([
+    work,
+    new Promise<null>(resolve => setTimeout(() => resolve(null), ms).unref?.()),
+  ]);
+}
+
+export function createSessionId(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+export async function saveDeviceAuthSession(
+  sessionId: string,
+  session: DeviceAuthSession,
+  now: number = Date.now()
+): Promise<void> {
+  const ttlSeconds = Math.max(1, Math.ceil((session.expiresAt - now) / 1000));
+
+  pruneMemorySessions(now);
+  memorySessions.set(sessionId, session);
+
+  if (!redis) return;
+  Promise.resolve(redis.setex(`${REDIS_KEY_PREFIX}${sessionId}`, ttlSeconds, JSON.stringify(session)))
+    .catch((error: any) => {
+      logger.debug(`Session not mirrored to Redis, memory only: ${error?.message}`);
+    });
+}
+
+export async function getDeviceAuthSession(
+  sessionId: string,
+  provider: DeviceAuthProvider,
+  now: number = Date.now()
+): Promise<DeviceAuthSession | null> {
+  if (typeof sessionId !== 'string' || !/^[0-9a-f]{64}$/.test(sessionId)) {
+    return null;
+  }
+
+  let session = memorySessions.get(sessionId) || null;
+
+  if (!session && redis) {
+    try {
+      // Bounded, otherwise a lookup that misses memory while Redis is down
+      // would hold the request open for as long as ioredis keeps retrying.
+      const raw = await withTimeout<string | null>(
+        redis.get(`${REDIS_KEY_PREFIX}${sessionId}`),
+        REDIS_READ_TIMEOUT_MS
+      );
+      if (raw) session = JSON.parse(raw) as DeviceAuthSession;
+    } catch (error: any) {
+      logger.debug(`Could not read session from Redis: ${error?.message}`);
+    }
+  }
+
+  if (!session || session.provider !== provider) return null;
+  if (session.expiresAt <= now) {
+    await deleteDeviceAuthSession(sessionId);
+    return null;
+  }
+
+  return session;
+}
+
+/**
+ * Records a poll and reports whether it came too soon. Callers that get `false`
+ * should answer "pending" without touching the provider.
+ */
+export async function registerPoll(
+  sessionId: string,
+  session: DeviceAuthSession,
+  now: number = Date.now()
+): Promise<boolean> {
+  if (now - session.lastPolledAt < session.pollIntervalMs) {
+    return false;
+  }
+
+  session.lastPolledAt = now;
+  await saveDeviceAuthSession(sessionId, session, now);
+  return true;
+}
+
+/** Backs off after a provider tells us we're polling too fast. */
+export async function widenPollInterval(
+  sessionId: string,
+  session: DeviceAuthSession,
+  now: number = Date.now()
+): Promise<void> {
+  session.pollIntervalMs += 2000;
+  await saveDeviceAuthSession(sessionId, session, now);
+}
+
+export async function deleteDeviceAuthSession(sessionId: string): Promise<void> {
+  memorySessions.delete(sessionId);
+  if (!redis) return;
+  Promise.resolve(redis.del(`${REDIS_KEY_PREFIX}${sessionId}`))
+    .catch((error: any) => {
+      logger.debug(`Could not delete session from Redis: ${error?.message}`);
+    });
+}

--- a/addon/lib/settingsRegistry.ts
+++ b/addon/lib/settingsRegistry.ts
@@ -216,7 +216,6 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     category: 'OAuth',
     type: 'string',
     default: '',
-    envOnly: true,
     validate: (value: string) => value === '' || ['oauth', 'pin', 'both'].includes(value.trim().toLowerCase()),
   },
   {

--- a/addon/lib/settingsRegistry.ts
+++ b/addon/lib/settingsRegistry.ts
@@ -209,6 +209,17 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     envOnly: true,
   },
   {
+    key: 'SIMKL_AUTH_MODE',
+    envVar: 'SIMKL_AUTH_MODE',
+    label: 'Simkl Auth Mode',
+    description: "Which Simkl connection flows to offer: 'oauth', 'pin', or 'both'. Defaults to 'pin' when no client secret is set.",
+    category: 'OAuth',
+    type: 'string',
+    default: '',
+    envOnly: true,
+    validate: (value: string) => value === '' || ['oauth', 'pin', 'both'].includes(value.trim().toLowerCase()),
+  },
+  {
     key: 'SIMKL_REDIRECT_URI',
     envVar: 'SIMKL_REDIRECT_URI',
     label: 'Simkl Redirect URI',
@@ -1020,6 +1031,15 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     category: 'Rate Limits',
     type: 'number',
     default: 20,
+  },
+  {
+    key: 'DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN',
+    envVar: 'DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN',
+    label: 'Device Auth Poll Rate Limit',
+    description: 'Maximum device/PIN authorization status polls per minute, across the Simkl PIN and Trakt device flows.',
+    category: 'Rate Limits',
+    type: 'number',
+    default: 240,
   },
   {
     key: 'JIKAN_MAX_CONCURRENT',

--- a/addon/lib/simkl.ts
+++ b/addon/lib/simkl.ts
@@ -10,6 +10,20 @@ export interface SimklTokens {
   // Note: Simkl access tokens never expire, no refresh_token
 }
 
+export interface SimklPinRequest {
+  device_code: string;
+  user_code: string;
+  verification_url: string;
+  expires_in: number;
+  interval: number;
+}
+
+export type SimklPinPoll =
+  | { status: 'authorized'; access_token: string }
+  | { status: 'pending' }
+  | { status: 'slow_down' }
+  | { status: 'expired' };
+
 export interface SimklUser {
   username: string;
   name?: string;
@@ -21,10 +35,81 @@ export class SimklClient {
   private clientSecret: string;
   private redirectUri: string;
 
-  constructor(clientId: string, clientSecret: string, redirectUri: string) {
+  // PIN flow needs only a client id, so these two stay empty there.
+  constructor(clientId: string, clientSecret: string = '', redirectUri: string = '') {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.redirectUri = redirectUri;
+  }
+
+  /**
+   * Start the PIN (device) flow. No client secret, no callback URL.
+   */
+  async requestPin(): Promise<SimklPinRequest> {
+    const params = new URLSearchParams({ client_id: this.clientId });
+    const response = await httpGet(`${SIMKL_API_BASE}/oauth/pin?${params.toString()}`);
+    const data = response.data;
+
+    if (!data || data.result !== 'OK' || !data.user_code) {
+      logger.error('Unexpected Simkl PIN response:', JSON.stringify(data));
+      throw new Error('Simkl did not return a PIN');
+    }
+
+    return {
+      device_code: String(data.device_code || ''),
+      user_code: String(data.user_code),
+      verification_url: String(data.verification_url || data.verification_uri || 'https://simkl.com/pin'),
+      expires_in: Number(data.expires_in) || 900,
+      interval: Number(data.interval) || 5,
+    };
+  }
+
+  /**
+   * Poll a pending PIN. Simkl returns result "OK" with an access token once the
+   * user has entered the code, and "KO" with either "Authorization pending" or
+   * "Slow down" while it is still waiting.
+   */
+  async pollPin(userCode: string): Promise<SimklPinPoll> {
+    const params = new URLSearchParams({ client_id: this.clientId });
+
+    let data: any;
+    try {
+      const response = await httpGet(
+        `${SIMKL_API_BASE}/oauth/pin/${encodeURIComponent(userCode)}?${params.toString()}`
+      );
+      data = response.data;
+    } catch (error: any) {
+      const status = error?.response?.status;
+
+      // A rejected client id is a configuration problem, not a user who hasn't
+      // typed the code yet. Let it surface instead of polling forever.
+      if (status === 401 || status === 403) {
+        logger.error(`Simkl rejected the client credentials (HTTP ${status})`);
+        throw error;
+      }
+
+      if (status === 429) {
+        return { status: 'slow_down' };
+      }
+
+      // Anything else is treated as transient, the next tick retries.
+      logger.debug(`Simkl PIN poll failed, treating as pending: ${error?.message}`);
+      return { status: 'pending' };
+    }
+
+    if (data && data.result === 'OK' && data.access_token) {
+      return { status: 'authorized', access_token: String(data.access_token) };
+    }
+
+    const message = typeof data?.message === 'string' ? data.message.toLowerCase() : '';
+    if (message.includes('expired') || message.includes('invalid')) {
+      return { status: 'expired' };
+    }
+    if (message.includes('slow down')) {
+      return { status: 'slow_down' };
+    }
+
+    return { status: 'pending' };
   }
 
   /**

--- a/addon/lib/simkl.ts
+++ b/addon/lib/simkl.ts
@@ -11,7 +11,6 @@ export interface SimklTokens {
 }
 
 export interface SimklPinRequest {
-  device_code: string;
   user_code: string;
   verification_url: string;
   expires_in: number;
@@ -47,8 +46,18 @@ export class SimklClient {
    */
   async requestPin(): Promise<SimklPinRequest> {
     const params = new URLSearchParams({ client_id: this.clientId });
-    const response = await httpGet(`${SIMKL_API_BASE}/oauth/pin?${params.toString()}`);
-    const data = response.data;
+    let data: any;
+    try {
+      const response = await httpGet(`${SIMKL_API_BASE}/oauth/pin?${params.toString()}`);
+      data = response.data;
+    } catch (error: any) {
+      const status = error?.response?.status;
+      if (status === 401 || status === 403) {
+        logger.error(`Simkl rejected the client credentials (HTTP ${status})`);
+        throw new Error('Simkl rejected this instance\'s client id');
+      }
+      throw error;
+    }
 
     if (!data || data.result !== 'OK' || !data.user_code) {
       logger.error('Unexpected Simkl PIN response:', JSON.stringify(data));
@@ -56,7 +65,6 @@ export class SimklClient {
     }
 
     return {
-      device_code: String(data.device_code || ''),
       user_code: String(data.user_code),
       verification_url: String(data.verification_url || data.verification_uri || 'https://simkl.com/pin'),
       expires_in: Number(data.expires_in) || 900,
@@ -101,10 +109,16 @@ export class SimklClient {
       return { status: 'authorized', access_token: String(data.access_token) };
     }
 
-    const message = typeof data?.message === 'string' ? data.message.toLowerCase() : '';
-    if (message.includes('expired') || message.includes('invalid')) {
+    // Simkl answers an unknown code by minting a fresh one and returning the
+    // step-1 body, which carries `device_code` and no `access_token`. Its
+    // documentation names that field as the signal that the code we polled is
+    // gone. Reading it as pending would keep polling, and every one of those
+    // polls mints another code, so this has to come before anything else.
+    if (data && data.device_code) {
       return { status: 'expired' };
     }
+
+    const message = typeof data?.message === 'string' ? data.message.toLowerCase() : '';
     if (message.includes('slow down')) {
       return { status: 'slow_down' };
     }

--- a/configure/src/components/DeviceAuthCard.tsx
+++ b/configure/src/components/DeviceAuthCard.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import type { DeviceAuthCode } from '@/hooks/useDeviceAuth';
+
+interface DeviceAuthCardProps {
+  code: DeviceAuthCode | null;
+  requesting: boolean;
+  disabled: boolean;
+  startLabel: string;
+  hint: string;
+  onStart: () => void;
+  onCancel: () => void;
+}
+
+/** Code display for the Simkl PIN flow. */
+export function DeviceAuthCard({
+  code,
+  requesting,
+  disabled,
+  startLabel,
+  hint,
+  onStart,
+  onCancel,
+}: DeviceAuthCardProps) {
+  if (!code) {
+    return (
+      <>
+        <Button onClick={onStart} className="w-full" disabled={disabled || requesting}>
+          {requesting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <ExternalLink className="mr-2 h-4 w-4" />
+          )}
+          {startLabel}
+        </Button>
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      </>
+    );
+  }
+
+  return (
+    <div className="space-y-3 p-4 border rounded-lg bg-gray-50 dark:bg-gray-900">
+      <p className="text-sm text-muted-foreground">
+        Enter this code at{" "}
+        <a href={code.verificationUrl} target="_blank" rel="noopener noreferrer" className="underline">
+          {code.verificationUrl.replace(/^https?:\/\//, "")}
+        </a>
+      </p>
+      <p className="text-3xl font-mono font-bold tracking-[0.3em] text-center select-all">
+        {code.userCode}
+      </p>
+      <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Waiting for you to approve the code...
+      </div>
+      <Button variant="ghost" className="w-full" onClick={onCancel}>
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/configure/src/components/sections/SimklIntegration.tsx
+++ b/configure/src/components/sections/SimklIntegration.tsx
@@ -10,6 +10,8 @@ import { Switch } from '@/components/ui/switch';
 import { ExternalLink, CheckCircle2, XCircle, Loader2, ChevronDown, Plus, Link2, BarChart3, Bookmark, TrendingUp, Sparkles, PlayCircle, Trash2 } from 'lucide-react';
 import { toast } from "sonner";
 import { apiCache } from '@/utils/apiCache';
+import { DeviceAuthCard } from '@/components/DeviceAuthCard';
+import { useDeviceAuth } from '@/hooks/useDeviceAuth';
 
 interface SimklIntegrationProps {
   isOpen: boolean;
@@ -18,14 +20,21 @@ interface SimklIntegrationProps {
 
 export function SimklIntegration({ isOpen, onClose }: SimklIntegrationProps) {
   const [simklClientId, setSimklClientId] = useState<string>("");
+  const [simklAuthMode, setSimklAuthMode] = useState<'oauth' | 'pin' | 'both'>('oauth');
   
   useEffect(() => {
     fetch("/api/config")
       .then(res => res.ok ? res.json() : null)
       .then(data => {
         if (data && data.simkl) setSimklClientId(data.simkl);
+        if (data && (data.simklAuthMode === 'pin' || data.simklAuthMode === 'both' || data.simklAuthMode === 'oauth')) {
+          setSimklAuthMode(data.simklAuthMode);
+        }
       });
   }, []);
+
+  const pinEnabled = simklAuthMode === 'pin' || simklAuthMode === 'both';
+  const oauthEnabled = simklAuthMode === 'oauth' || simklAuthMode === 'both';
 
   const { config, setConfig, auth } = useConfig();
   const [tempTokenId, setTempTokenId] = useState(config.apiKeys?.simklTokenId || "");
@@ -108,6 +117,31 @@ export function SimklIntegration({ isOpen, onClose }: SimklIntegrationProps) {
     toast.info("Complete the authorization in the new window and paste the Token ID below");
   };
 
+  const applyToken = (tokenId: string, connectedUsername: string) => {
+    setUsername(connectedUsername);
+    setTempTokenId(tokenId);
+    setConfig(prev => ({
+      ...prev,
+      apiKeys: {
+        ...prev.apiKeys,
+        simklTokenId: tokenId,
+      },
+    }));
+    setIsConnected(true);
+    toast.success(`Connected as @${connectedUsername}`);
+  };
+
+  // No callback URL here, the server talks to Simkl directly while the user
+  // types the code on simkl.com/pin.
+  const pinAuth = useDeviceAuth({
+    startPath: "/api/auth/simkl/pin",
+    statusPath: "/api/auth/simkl/pin/status",
+    cancelPath: "/api/auth/simkl/pin/cancel",
+    active: isOpen,
+    providerLabel: "Simkl",
+    onAuthorized: applyToken,
+  });
+
   const handleSave = async () => {
     if (!tempTokenId.trim()) {
       toast.error("Please enter a valid Token ID");
@@ -125,18 +159,7 @@ export function SimklIntegration({ isOpen, onClose }: SimklIntegrationProps) {
       if (response.ok) {
         const data = await response.json();
         if (data.provider === 'simkl') {
-          setUsername(data.username);
-          
-          setConfig(prev => ({
-            ...prev,
-            apiKeys: {
-              ...prev.apiKeys,
-              simklTokenId: tempTokenId.trim(),
-            },
-          }));
-
-          setIsConnected(true);
-          toast.success(`Connected as @${data.username}`);
+          applyToken(tempTokenId.trim(), data.username);
         } else {
           toast.error("Invalid Simkl token");
         }
@@ -398,24 +421,44 @@ export function SimklIntegration({ isOpen, onClose }: SimklIntegrationProps) {
                     </div>
                   </div>
 
-                  <div className="space-y-2">
-                    <Label>Step 1: Authorize Simkl</Label>
-                    <Button onClick={handleConnect} className="w-full" disabled={!simklClientId}>
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Authorize with Simkl
-                    </Button>
-                    {!simklClientId && (
-                      <p className="text-xs text-red-500 mt-2">
-                        Instance owner has not yet set up the Simkl integration.
+                  {pinEnabled && (
+                    <div className="space-y-2">
+                      <Label>Connect with a PIN</Label>
+                      <DeviceAuthCard
+                        code={pinAuth.code}
+                        requesting={pinAuth.requesting}
+                        disabled={!simklClientId}
+                        startLabel="Get a Simkl PIN"
+                        hint="Opens simkl.com/pin in a new tab. No public callback URL needed."
+                        onStart={pinAuth.start}
+                        onCancel={pinAuth.cancel}
+                      />
+                    </div>
+                  )}
+
+                  {oauthEnabled && (
+                    <div className="space-y-2">
+                      <Label>{pinEnabled ? "Or authorize in a browser window" : "Step 1: Authorize Simkl"}</Label>
+                      <Button onClick={handleConnect} className="w-full" disabled={!simklClientId}>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        Authorize with Simkl
+                      </Button>
+                      <p className="text-xs text-muted-foreground">
+                        Opens a new window. You'll receive a Token ID to paste below.
                       </p>
-                    )}
-                    <p className="text-xs text-muted-foreground">
-                      Opens a new window. You'll receive a Token ID to paste below.
+                    </div>
+                  )}
+
+                  {!simklClientId && (
+                    <p className="text-xs text-red-500">
+                      Instance owner has not yet set up the Simkl integration.
                     </p>
-                  </div>
+                  )}
 
                   <div className="space-y-2">
-                    <Label htmlFor="simkl-token">Step 2: Paste Token ID</Label>
+                    <Label htmlFor="simkl-token">
+                      {oauthEnabled ? "Step 2: Paste Token ID" : "Already have a Token ID?"}
+                    </Label>
                     <Input
                       id="simkl-token"
                       placeholder="Paste your Simkl Token ID here"

--- a/configure/src/hooks/useDeviceAuth.ts
+++ b/configure/src/hooks/useDeviceAuth.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+export interface DeviceAuthCode {
+  sessionId: string;
+  userCode: string;
+  verificationUrl: string;
+  interval: number;
+}
+
+interface UseDeviceAuthOptions {
+  /** Endpoint that starts the flow (POST), its polling counterpart (GET), and
+   *  the one that drops a session the user gave up on (POST). */
+  startPath: string;
+  statusPath: string;
+  cancelPath: string;
+  /** Polling pauses while the dialog is closed. */
+  active: boolean;
+  providerLabel: string;
+  onAuthorized: (tokenId: string, username: string) => void;
+}
+
+/**
+ * Drives the Simkl PIN flow: ask the server for a code, show it, then poll
+ * until the server has a token.
+ */
+export function useDeviceAuth({
+  startPath,
+  statusPath,
+  cancelPath,
+  active,
+  providerLabel,
+  onAuthorized,
+}: UseDeviceAuthOptions) {
+  const [code, setCode] = useState<DeviceAuthCode | null>(null);
+  const [requesting, setRequesting] = useState(false);
+  const onAuthorizedRef = useRef(onAuthorized);
+  onAuthorizedRef.current = onAuthorized;
+
+  const cancel = useCallback(() => {
+    if (code) {
+      // Best effort, the session expires on its own anyway.
+      fetch(cancelPath, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: code.sessionId }),
+      }).catch(() => undefined);
+    }
+    setCode(null);
+  }, [cancelPath, code]);
+
+  const start = useCallback(async () => {
+    setRequesting(true);
+    try {
+      const response = await fetch(startPath, { method: 'POST' });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        toast.error(data?.error || `Could not start the ${providerLabel} authorization`);
+        return;
+      }
+      const data = await response.json();
+      setCode({
+        sessionId: data.sessionId,
+        userCode: data.userCode,
+        verificationUrl: data.verificationUrl,
+        interval: Math.max(2, Number(data.interval) || 5),
+      });
+      window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      console.error(`${providerLabel} device auth request error:`, error);
+      toast.error(`Could not start the ${providerLabel} authorization`);
+    } finally {
+      setRequesting(false);
+    }
+  }, [startPath, providerLabel]);
+
+  useEffect(() => {
+    if (!code || !active) return;
+
+    let cancelled = false;
+    const timer = window.setInterval(async () => {
+      try {
+        const response = await fetch(`${statusPath}?sessionId=${encodeURIComponent(code.sessionId)}`);
+        if (cancelled) return;
+
+        // Rate limited, wait for the next tick.
+        if (response.status === 429) return;
+
+        const data = await response.json().catch(() => null);
+
+        if (!response.ok && response.status !== 404) {
+          toast.error(data?.error || `Could not check the ${providerLabel} authorization status`);
+          setCode(null);
+          return;
+        }
+
+        if (data?.status === 'authorized' && data.tokenId) {
+          setCode(null);
+          onAuthorizedRef.current(data.tokenId, data.username);
+        } else if (data?.status === 'slow_down') {
+          // Provider says we're polling too fast, so widen the gap.
+          setCode(prev => (prev ? { ...prev, interval: prev.interval + 2 } : prev));
+        } else if (data?.status === 'expired') {
+          setCode(null);
+          toast.error(`The ${providerLabel} code expired. Please request a new one.`);
+        }
+      } catch (error) {
+        console.error(`${providerLabel} device auth status error:`, error);
+      }
+    }, code.interval * 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [code, active, statusPath, providerLabel]);
+
+  return { code, requesting, start, cancel };
+}

--- a/configure/src/hooks/useDeviceAuth.ts
+++ b/configure/src/hooks/useDeviceAuth.ts
@@ -51,9 +51,18 @@ export function useDeviceAuth({
 
   const start = useCallback(async () => {
     setRequesting(true);
+    // Opened before the request, while the click is still the reason we are
+    // running. A window.open after an await has lost the user gesture and every
+    // major browser blocks it, which left the card telling people a tab had
+    // opened when it had not. `noopener` is not passed here because it makes
+    // open() return null, and we need the handle to navigate the tab once the
+    // code arrives; clearing `opener` on the new window buys the same thing.
+    const pinTab = window.open('', '_blank');
+    if (pinTab) pinTab.opener = null;
     try {
       const response = await fetch(startPath, { method: 'POST' });
       if (!response.ok) {
+        pinTab?.close();
         const data = await response.json().catch(() => null);
         toast.error(data?.error || `Could not start the ${providerLabel} authorization`);
         return;
@@ -65,8 +74,15 @@ export function useDeviceAuth({
         verificationUrl: data.verificationUrl,
         interval: Math.max(2, Number(data.interval) || 5),
       });
-      window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+      // Blocked anyway, or the browser handed back nothing: the card still
+      // shows the URL as a link, so this is the convenience path only.
+      if (pinTab) {
+        pinTab.location.href = data.verificationUrl;
+      } else {
+        window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+      }
     } catch (error) {
+      pinTab?.close();
       console.error(`${providerLabel} device auth request error:`, error);
       toast.error(`Could not start the ${providerLabel} authorization`);
     } finally {

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -218,12 +218,27 @@ to every visitor, so which one you reach for depends on who uses the instance.
 - **Get it**: https://simkl.com/oauth/applications
 
 #### `SIMKL_CLIENT_SECRET`
-- **Required for SimKL integration**: Yes
+- **Required for SimKL integration**: Only for the OAuth flow (not needed when `SIMKL_AUTH_MODE=pin`)
 - **Description**: SimKL API client secret for enabling SimKL account integration
 - **Get it**: https://simkl.com/oauth/applications
 
+#### `SIMKL_AUTH_MODE`
+- **Required**: No
+- **Default**: `pin` when `SIMKL_CLIENT_SECRET` is unset, otherwise `oauth`
+- **Values**: `oauth`, `pin`, `both`
+- **Description**: Which SimKL connection flow(s) the configure page offers.
+  - `oauth` - the browser-redirect flow. Needs `SIMKL_CLIENT_SECRET` plus a publicly reachable `HOST_NAME`/`SIMKL_REDIRECT_URI` registered with SimKL.
+  - `pin` - the PIN (device) flow. The server asks SimKL for a short code, the user enters it at https://simkl.com/pin, and the server polls until SimKL hands back an access token. Needs only `SIMKL_CLIENT_ID`: no client secret and no inbound callback, so it works on instances that are not reachable from the internet.
+  - `both` - offers each flow side by side.
+- **Example**: `SIMKL_AUTH_MODE=pin`
+
+#### `DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN`
+- **Required**: No
+- **Default**: `240`
+- **Description**: Instance-wide cap on PIN authorization status polls per minute on `/api/auth/simkl/pin/status`. Only applies when Redis is available.
+
 #### `SIMKL_REDIRECT_URI`
-- **Required for SimKL integration**: No (optional)
+- **Required for SimKL integration**: No (optional, and unused when `SIMKL_AUTH_MODE=pin`)
 - **Description**: Redirect URI for SimKL OAuth. If not set, defaults to `${HOST_NAME}/api/auth/simkl/callback`. Must match the value set in your SimKL app settings if explicitly set.
 - **Example**: `SIMKL_REDIRECT_URI=https://your-domain.com/api/auth/simkl/callback`
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -111,6 +111,20 @@ node addon/server.js
 > client ids are public by design and their secrets are not published.) See
 > [Environment Variables](ENVIRONMENT_VARIABLES.md#api-keys).
 
+> **Connecting SimKL without a public URL?** The configure page can show a short
+> code to enter at https://simkl.com/pin, and the server polls SimKL for the token.
+> Only `SIMKL_CLIENT_ID` is required, no client secret and no inbound callback to
+> your instance. For a private instance:
+>
+> ```
+> SIMKL_CLIENT_ID=your_client_id
+> SIMKL_AUTH_MODE=pin
+> ```
+>
+> `pin` is already the default when no `SIMKL_CLIENT_SECRET` is set, but setting it
+> explicitly keeps the flow from switching back to OAuth if a secret is ever added.
+> See [`SIMKL_AUTH_MODE`](ENVIRONMENT_VARIABLES.md#simkl_auth_mode).
+
 ## Getting API Keys
 
 ### TMDB API

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/opc/aiometadata/node_modules


### PR DESCRIPTION
## Summary

Adds Simkl PIN authentication so self-hosted AIOMetadata instances can link a Simkl account without a publicly reachable callback URL. Simkl's PIN flow is outbound only: the server requests a short code, the user enters it at simkl.com/pin, and the server polls Simkl for the token, so nothing needs to reach the instance from the internet. Needs only `SIMKL_CLIENT_ID`, no client secret. Existing OAuth authentication is unchanged; it remains the selected default when a client secret is configured.

## Linked issue

Required for all non-trivial code changes.

Closes #673

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

Simkl documents the PIN/device flow for media servers and similar services that cannot receive an OAuth callback, which is exactly the self-hosted case. The browser never sees the Simkl access token: the server holds an opaque session, polls Simkl, stores the token, and returns only the internal token ID and username.

The existing Simkl token persistence was extracted from the OAuth callback so both authentication paths use the same storage and account-matching logic, minimizing behavioral differences between OAuth and PIN authorization.

Sessions live in memory, with best-effort Redis mirroring to support multi-process deployments. Redis writes are not awaited and reads are bounded at one second, because with nothing listening on 6379 ioredis holds a command for roughly 16 seconds, which would otherwise stall every poll. Simkl's polling interval is stored per session and enforced server-side, so polls arriving early are answered without contacting Simkl, and a `Slow down` response widens that session's interval rather than relying on the client to back off. A 401/403 from Simkl surfaces as an error instead of looking like a user who hasn't typed the code yet.

`SIMKL_AUTH_MODE` selects the flow and defaults to `pin` only when no client secret is set, so existing OAuth installs are untouched.

Known limitation: the poll-interval check is a read-check-write, enforced per process and not atomic across replicas sharing Redis. Likewise, a session created while Redis is down is only visible to the process that created it. Both are acceptable for the single-instance self-hosted target and would need an atomic Redis operation if distributed deployments become a requirement.

## Testing

Verified manually against the live Simkl API, on a locally booted instance with Redis deliberately not running so the in-memory path was the one under test.

- end-to-end authorization: PIN requested, entered at simkl.com/pin, polled to completion, token persisted, session deleted afterwards
- the stored access token was verified directly against `api.simkl.com/users/settings`, which returned the expected account
- per-session interval gating measured: the first poll reaches Simkl, polls inside the interval return `pending` without an upstream call
- cancellation deletes the session, is idempotent, and a later status request returns 404
- unknown, malformed and missing session IDs return 404 without leaking state
- `no-store` cache headers on the new routes, and the routes return 404 when `SIMKL_AUTH_MODE` excludes PIN
- static checks: `tsc` for both `tsconfig.backend.json` and `tsconfig.app.json`, `eslint` on all touched files, `npm run check:env`, `npm run build`

Not covered: the React UI was not driven in a browser, only the endpoints it calls; no PIN was allowed to expire naturally. The 401/403 branch was not exercised because Simkl's PIN endpoints currently return HTTP 200 even for an invalid client ID; that branch is defensive handling of the HTTP contract rather than an observed Simkl response.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The project has no test framework or test script, so introducing one was treated as outside the scope of this change. The flow was verified through the manual end-to-end and endpoint-level testing above.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

`.env.example`, `docs/ENVIRONMENT_VARIABLES.md` (`SIMKL_AUTH_MODE`, `DEVICE_AUTH_POLL_RATE_LIMIT_PER_MIN`) and `docs/self-hosting.md`, which now shows the recommended private-instance configuration explicitly.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [x] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:

The implementation was written with AI assistance under my direction, covering the Simkl PIN flow, the session store, and the polling and rate-limiting behaviour. I directed the approach, reviewed every changed line, and verified the behaviour myself, including the end-to-end Simkl authorization against the live API. Findings were checked against the source and Simkl's API before being applied.