### PR TITLE
Closed - carried locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,6 +341,11 @@ TRAKT_MIN_TIME=200
 CATALOG_TTL=86400
 # Meta cache time-to-live in seconds (default: 604800 = 7 days)
 META_TTL=604800
+# TMDB movie/tv/collection detail cache time-to-live in seconds (default: 86400 = 24 hours).
+# These are the largest entries written to Redis. If TMDB_API_BASE points at your own
+# caching proxy, that proxy already holds this data, so you can lower this — or set it
+# to 0 to skip caching these responses entirely.
+# TMDB_DETAIL_TTL=86400
 
 # -- Timezone Configuration --
 # Set the timezone for the server (e.g., America/New_York)

--- a/addon/lib/getTmdb.ts
+++ b/addon/lib/getTmdb.ts
@@ -21,8 +21,30 @@ import {
 } from './tmdbCacheNormalizers.js';
 import { LRUCache } from 'lru-cache';
 import { UserConfig } from '../types/index';
+import { envInt } from '../utils/envNumber';
 
 const TMDB_API_URL = 'https://api.themoviedb.org/3';
+
+/**
+ * TTL for the `/movie/{id}`, `/tv/{id}` and `/collection/{id}` detail responses.
+ *
+ * These are by far the largest thing this addon puts in Redis: they carry a wide
+ * `append_to_response` (images, translations, seasons), so a single entry runs to
+ * tens of KB even after compression. On a shared instance they can dominate the
+ * keyspace and push out the per-user meta and catalog entries, which are the
+ * expensive ones to rebuild.
+ *
+ * Deployments that already front TMDB with their own caching proxy (`TMDB_API_BASE`
+ * pointing at a passthrough cache) hold this data a second time, for longer, and
+ * closer to the source — for them the Redis copy earns nothing and this can be
+ * lowered, or set to `0` to skip caching these responses entirely. Deployments that
+ * talk to TMDB directly should leave it alone.
+ *
+ * Read per call rather than at module load, so it follows a hot-reloaded env.
+ */
+function TMDB_DETAIL_TTL(): number {
+  return envInt('TMDB_DETAIL_TTL', 24 * 60 * 60);
+}
 const ACCOUNT_DETAILS_CACHE_MAX = 2000;
 const ACCOUNT_DETAILS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const COMMA_LIST_QUERY_PARAMS = new Set([
@@ -466,7 +488,7 @@ export async function movieInfo(params: any, config: UserConfig) {
   const cacheKey = `tmdb:movie:detail:${id}${getTmdbQueryCacheSuffix(normalizedQueryParams)}`;
   return cacheWrapGlobal(cacheKey, () =>
     makeTmdbRequest(`/movie/${id}`, getApiKey(config), normalizedQueryParams, 'GET', null, config),
-    24 * 60 * 60
+    TMDB_DETAIL_TTL()
   );
 }
 export async function tvInfo(params: any, config: UserConfig) {
@@ -475,7 +497,7 @@ export async function tvInfo(params: any, config: UserConfig) {
   const cacheKey = `tmdb:tv:detail:${id}${getTmdbQueryCacheSuffix(normalizedQueryParams)}`;
   return cacheWrapGlobal(cacheKey, () =>
     makeTmdbRequest(`/tv/${id}`, getApiKey(config), normalizedQueryParams, 'GET', null, config),
-    24 * 60 * 60
+    TMDB_DETAIL_TTL()
   );
 }
 
@@ -610,7 +632,7 @@ export async function collectionInfo(params: any, config: UserConfig) {
   const cacheKey = `tmdb:collection:detail:${id}${getTmdbQueryCacheSuffix(normalizedQueryParams)}`;
   return cacheWrapGlobal(cacheKey, () =>
     makeTmdbRequest(`/collection/${id}`, getApiKey(config), normalizedQueryParams, 'GET', null, config),
-    24 * 60 * 60
+    TMDB_DETAIL_TTL()
   );
 }
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -95,6 +95,11 @@ cp .env.example .env
 - **Description**: Redis connection URL for caching (required for the app to function)
 - **Example**: `REDIS_URL=redis://localhost:6379`
 
+### `TMDB_DETAIL_TTL`
+- **Default**: `86400` (24 hours)
+- **Description**: Time-to-live, in seconds, for cached TMDB `/movie/{id}`, `/tv/{id}` and `/collection/{id}` detail responses. These are the largest entries the addon writes to Redis — they carry a wide `append_to_response` (images, translations, seasons), so one entry can run to tens of KB even after compression, and on a busy shared instance they can crowd out the per-user meta and catalog entries that are far more expensive to rebuild. If `TMDB_API_BASE` already points at your own caching proxy, that proxy holds the same data for longer and closer to the source, so the Redis copy earns little: lower this, or set it to `0` to skip caching these responses entirely. Leave it at the default when talking to TMDB directly.
+- **Example**: `TMDB_DETAIL_TTL=3600`
+
 ### `CATALOG_REFRESH_AHEAD_ENABLED`
 - **Default**: `true`
 - **Description**: Rebuild a catalog in the background when a request arrives near the end of its cache lifetime, so the cached copy is served immediately and the rebuild never lands on a user request. Only catalogs are affected. Cache TTLs are unchanged, so nothing is served staler than `CATALOG_TTL` already allows.


### PR DESCRIPTION
Closing this — we're carrying this change locally in our own build instead of proposing it upstream. Nothing here needs action from the maintainers.
