### PR TITLE
fix(catalogs): carry the age rating on anime catalog rows

### DIFF
--- a/addon/lib/getCache.ts
+++ b/addon/lib/getCache.ts
@@ -3,7 +3,7 @@ const { loadConfigFromDatabase }: any = require('./configApi');
 const consola: any = require('consola');
 const crypto: any = require('crypto');
 const { isMetricsDisabled }: any = require('./metricsConfig');
-const { allowsUnrated, hasAgeRatingCap }: any = require('../utils/ageRating');
+const { allowsUnrated, hasAgeRatingCap, stripCertificationLinks, applyDisplayAgeRatingProjection }: any = require('../utils/ageRating');
 const {
   decodeCachePayload,
   encodeCachePayload,
@@ -1069,29 +1069,6 @@ function applyBlurThumbProjection(meta: any, config: any): any {
     }
     return { ...video, thumbnail: `${blurPrefix}${encodeURIComponent(rawThumbnail)}` };
   });
-  return meta;
-}
-
-function stripCertificationLinks(links: any[], certification: string): any[] {
-  if (!Array.isArray(links) || !certification) return links;
-  return links.filter((link: any) => !(link?.name === certification && link?.category === 'Genres'));
-}
-
-function applyDisplayAgeRatingProjection(meta: any, config: any): any {
-  const certification = meta?.app_extras?.certification;
-  if (!certification) return meta;
-  const displayCert = meta?.app_extras?.certificationLocal || certification;
-  const links = Array.isArray(meta.links) ? stripCertificationLinks(meta.links, certification).filter((l: any) => !(l?.name === displayCert && l?.category === 'Genres')) : [];
-  if (config.displayAgeRating) {
-    const imdbId = meta.id?.match(/^tt\d+/)?.[0] || meta.imdb_id || meta._imdbId;
-    const tmdbPath = meta.type === 'series' ? 'tv' : 'movie';
-    const url = imdbId
-      ? `https://www.imdb.com/title/${imdbId}/parentalguide/`
-      : `https://www.themoviedb.org/${tmdbPath}/${meta.id}`;
-    meta.links = [{ name: displayCert, category: 'Genres', url }, ...links];
-  } else if (Array.isArray(meta.links)) {
-    meta.links = links;
-  }
   return meta;
 }
 

--- a/addon/utils/ageRating.ts
+++ b/addon/utils/ageRating.ts
@@ -41,6 +41,34 @@ export function hasAgeRatingCap(config: { ageRating?: unknown } | null | undefin
   return typeof cap === 'string' && cap !== '' && cap.toLowerCase() !== 'none';
 }
 
+export function stripCertificationLinks(links: any[], certification: string): any[] {
+  if (!Array.isArray(links) || !certification) return links;
+  return links.filter((link: any) => !(link?.name === certification && link?.category === 'Genres'));
+}
+
+/**
+ * Clients read an age rating off the first of `meta.links`, so the certification has to
+ * be restated there. Idempotent: any chip already present is stripped before the current
+ * one is prepended, which lets a meta be projected more than once without stacking.
+ */
+export function applyDisplayAgeRatingProjection(meta: any, config: any): any {
+  const certification = meta?.app_extras?.certification;
+  if (!certification) return meta;
+  const displayCert = meta?.app_extras?.certificationLocal || certification;
+  const links = Array.isArray(meta.links) ? stripCertificationLinks(meta.links, certification).filter((l: any) => !(l?.name === displayCert && l?.category === 'Genres')) : [];
+  if (config.displayAgeRating) {
+    const imdbId = meta.id?.match(/^tt\d+/)?.[0] || meta.imdb_id || meta._imdbId;
+    const tmdbPath = meta.type === 'series' ? 'tv' : 'movie';
+    const url = imdbId
+      ? `https://www.imdb.com/title/${imdbId}/parentalguide/`
+      : `https://www.themoviedb.org/${tmdbPath}/${meta.id}`;
+    meta.links = [{ name: displayCert, category: 'Genres', url }, ...links];
+  } else if (Array.isArray(meta.links)) {
+    meta.links = links;
+  }
+  return meta;
+}
+
 /**
  * Catalog rows carry no certification at all, so treating unknown as blocked empties
  * them outright. Opting out is the strict reading and stays available.

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -15,7 +15,7 @@ const { getImdbRating } = require('../lib/getImdbRating');
 const consola = require('consola');
 const { cacheWrapMetaSmart, cacheWrapGlobal } = require('../lib/getCache');
 const { getReleaseAvailability } = require('./releaseAvailability');
-const { malRatingToCertification, isUnratedCertification } = require('./ageRating');
+const { malRatingToCertification, isUnratedCertification, applyDisplayAgeRatingProjection } = require('./ageRating');
 const wikiMappings = require('../lib/wiki-mapper.js');
 function CATALOG_TTL() { return parseInt(process.env.CATALOG_TTL || 1 * 24 * 60 * 60, 10); }
 const buildInfo = require('../lib/buildInfo');
@@ -2025,6 +2025,20 @@ function getKitsuGenresForItem(item, included = [], allowIncludedFallback = fals
     .filter(Boolean);
 }
 
+/**
+ * Anime catalog rows are built here instead of by getMeta, so the certification the
+ * parser had already resolved stayed on the meta as a bare field and never reached
+ * `app_extras`, where the display projection looks for it. A row therefore arrived
+ * without the rating its movie and series counterparts carry, and the chip only
+ * appeared once the meta request landed behind it. Restate it the way the meta
+ * builders do, and project it so the row ships the same `links` they do.
+ */
+function attachAnimeCatalogCertification(meta, config) {
+  if (!meta || isUnratedCertification(meta.certification)) return meta;
+  meta.app_extras = { ...(meta.app_extras || {}), certification: meta.certification };
+  return applyDisplayAgeRatingProjection(meta, config);
+}
+
 async function parseAnimeCatalogMeta(anime, config, language, descriptionFallback = null) {
   if (!anime || !anime.mal_id) return null;
 
@@ -2139,7 +2153,7 @@ async function parseAnimeCatalogMeta(anime, config, language, descriptionFallbac
       name: anime.title_english || anime.title
     });
   }
-  return {
+  return attachAnimeCatalogCertification({
     id:  `mal:${malId}`,
     type: stremioType,
     logo: stremioType === 'movie' ? await tmdb.getTmdbMovieLogo(tmdbId, config) : await tmdb.getTmdbSeriesLogo(tmdbId, config),
@@ -2164,7 +2178,7 @@ async function parseAnimeCatalogMeta(anime, config, language, descriptionFallbac
       defaultVideoId: stremioType === 'movie' ? mapping?.imdb_id ? mapping?.imdb_id: (kitsuId ? `kitsu:${kitsuId}` : `mal:${malId}`): null,
       hasScheduledVideos: stremioType === 'series',
     },
-  };
+  }, config);
 }
 
 /**
@@ -2399,7 +2413,7 @@ async function parseAnimeCatalogMetaBatch(animes, config, language, includeVideo
           return metaRatingLevel <= userRatingLevel;
         });
       }
-      return metas;
+      return metas.map(meta => attachAnimeCatalogCertification(meta, config));
     } catch (error) {
       logger.warn(`[parseAnimeCatalogMetaBatch] Kitsu batch fetch failed:`, error.message);
     }
@@ -2531,7 +2545,7 @@ async function parseAnimeCatalogMetaBatch(animes, config, language, includeVideo
     }
   }));
   
-  return results.filter(Boolean);
+  return results.filter(Boolean).map(meta => attachAnimeCatalogCertification(meta, config));
 }
 
 /**


### PR DESCRIPTION
## Summary

Anime catalog rows ship without the age rating that movie and series rows carry, so the rating chip appears only once the meta request lands behind the row — on the detail page this reads as the information line changing a moment after it opens. Movie and series catalogs build their rows through `getMeta`, which sets `app_extras.certification` and runs the display projection; anime catalogs build theirs in `parseAnimeCatalogMeta` / `parseAnimeCatalogMetaBatch`, which resolve the certification correctly but leave it as a bare top-level `certification` field where the projection never looks. This restates the value in `app_extras` and projects the row the way the meta builders do.

## Linked issue

Closes #704

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

The certification was already correct and already computed — only its placement was wrong — so the fix restates it where `applyDisplayAgeRatingProjection` looks rather than re-resolving anything. That keeps the displayed rating provably identical to what the meta path returns and makes the change impossible to get wrong for a given title.

`applyDisplayAgeRatingProjection` and `stripCertificationLinks` move from `lib/getCache` to `utils/ageRating`, beside the rest of the rating logic, so the catalog and meta paths share one implementation instead of duplicating it. The alternative — rebuilding the chip inside the anime parser — would have left two copies to drift apart. `parseProps` already depends on `getCache`, so this adds no new module edge.

Rows that are genuinely unrated are skipped via the existing `isUnratedCertification`, so a `"None"` rating does not become a chip. The projection is idempotent — an existing chip is stripped before the current one is prepended — so a meta projected more than once is unchanged.

Tradeoff: the anime parsers now read `config.displayAgeRating`, which they did not before. That is the same config the meta path already consults, so the two cannot disagree.

## Testing

Built from this branch and run against a real configuration with its own Redis and a copy of the database, so no shared state was touched.

Anime catalogs, after the change:

```
mal.top_anime     kitsu:46474  cert=PG    app_extras.cert=PG  links[0]=PG
                  kitsu:3936   cert=R     app_extras.cert=R   links[0]=R
                  kitsu:49847  cert=None  app_extras.cert=-   (no chip, correctly unrated)
anilist.trending  50 items | 23 with rating chip | 27 genuinely unrated
mal.airing        22 items | 10 with rating chip | 12 genuinely unrated
mal.seasons       23 items | 12 with rating chip | 11 genuinely unrated
```

Every row is either chipped or genuinely unrated and the counts account for all items, so nothing is dropped. The catalog rating now matches what the meta returns for the same id (`kitsu:46474` → `PG`, `kitsu:3936` → `R`), which is what removes the late change.

Regression checks:

- `meta/anime/kitsu:46474` and `kitsu:3936` still emit exactly one rating link, confirming the projection does not stack.
- `catalog/series/tmdb.top` is unchanged in its rating fields (`TV-14`, `TV-MA`, `TV-14`), confirming the `getCache` move is inert.

`npm run build:backend` and `npx eslint` on the three changed files both pass.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The repository has no test suite or `test` script, so there were no existing tests to run and no harness to add to. Verification was done end to end against a running instance, as described above.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

The new helper carries a comment explaining why anime rows need it, and the moved projection keeps its note about idempotency.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:
