### PR TITLE
fix(kitsu): drop the expiring signature from cached Kitsu image urls

### DIFF
--- a/addon/lib/kitsuCacheNormalizers.ts
+++ b/addon/lib/kitsuCacheNormalizers.ts
@@ -40,10 +40,27 @@ function pickDefined(source: any, keys: string[]) {
 }
 
 //flatten to .original since we only consume it
+/**
+ * Kitsu sometimes hands back a presigned storage URL carrying `X-Amz-Expires=900`, so
+ * the link dies fifteen minutes after it is issued while the meta around it is cached
+ * for far longer. The client then gets a 401 upstream, the art proxy turns that into a
+ * 502, and the title renders with no image at all while its neighbours are fine -
+ * Gintama: The Final (kitsu:43683) against the rest of the franchise.
+ *
+ * The object is served publicly without the signature, so dropping the query restores a
+ * permanent URL. Only signed URLs are touched, and only the query is removed, so an
+ * unsigned URL and any meaningful path are left exactly as they are.
+ */
+function stripExpiringSignature(url: string): string {
+  if (typeof url !== 'string' || !url.includes('X-Amz-Signature')) return url;
+  const query = url.indexOf('?');
+  return query === -1 ? url : url.slice(0, query);
+}
+
 function flattenImageToOriginal(image: any): { original: string } | null {
   if (!image || typeof image !== 'object') return image;
   if (!image.original) return null;
-  return { original: image.original };
+  return { original: stripExpiringSignature(image.original) };
 }
 
 

--- a/addon/lib/kitsuCacheNormalizers.ts
+++ b/addon/lib/kitsuCacheNormalizers.ts
@@ -40,17 +40,8 @@ function pickDefined(source: any, keys: string[]) {
 }
 
 //flatten to .original since we only consume it
-/**
- * Kitsu sometimes hands back a presigned storage URL carrying `X-Amz-Expires=900`, so
- * the link dies fifteen minutes after it is issued while the meta around it is cached
- * for far longer. The client then gets a 401 upstream, the art proxy turns that into a
- * 502, and the title renders with no image at all while its neighbours are fine -
- * Gintama: The Final (kitsu:43683) against the rest of the franchise.
- *
- * The object is served publicly without the signature, so dropping the query restores a
- * permanent URL. Only signed URLs are touched, and only the query is removed, so an
- * unsigned URL and any meaningful path are left exactly as they are.
- */
+/** Kitsu presigns some storage urls; the query is signing parameters and expires in
+ *  15 minutes, while the object stays public without them. */
 function stripExpiringSignature(url: string): string {
   if (typeof url !== 'string' || !url.includes('X-Amz-Signature')) return url;
   const query = url.indexOf('?');


### PR DESCRIPTION
## Summary

Kitsu sometimes returns a presigned storage url carrying `X-Amz-Expires=900`, so the link dies fifteen minutes after it is issued while the meta holding it is cached for far longer. Every later request gets 401 from storage, the art proxy turns that into 502, and the title renders with no image while its neighbours are fine. This strips the signature before the value is cached, which restores a permanent url.

## Linked issue

Closes #705

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

`flattenImageToOriginal` is the single point every Kitsu poster, cover and episode thumbnail passes through on its way into the cache, so normalising there fixes all three at once and guarantees no cached meta can carry a doomed url. Rewriting the host was the alternative and was rejected: Kitsu serves at least three url shapes (`media.kitsu.app/anime/poster_images/<id>/original.jpg`, `media.kitsu.app/anime/<id>/poster/...` and the storage host), so host rewriting would have to guess, while dropping the query is correct for all of them.

Only urls containing `X-Amz-Signature` are touched, and only the query is removed, so an unsigned url and any meaningful path are left byte-identical.

## Testing

Reproduced on 2.16.5 with Gintama: The Final (`kitsu:43683`), whose poster came back signed while the rest of the franchise came back on `media.kitsu.app` and kept working:

```
poster url            .../anime/43683/poster_image/<hash>.jpg?X-Amz-Expires=900&X-Amz-Signature=...
through the art proxy HTTP 502    16 bytes   text/plain
upstream directly     HTTP 401   218 bytes
```

The object is public without the signature, so the same url works once the query is dropped:

```
.../anime/43683/poster_image/<hash>.jpg                  HTTP 200  117875 bytes
https://media.kitsu.app/anime/43683/poster_image/<hash>.jpg  HTTP 200  117875 bytes
```

After the change, `meta/anime/kitsu:43683` returns an unsigned url that fetches `HTTP 200, 117875 bytes, image/jpeg`. Sweeping the six anime catalogs on my board afterwards: 166 rows, 104 unique posters, **0 still carrying an expiring signature and 0 non-200**.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The repository has no test suite or `test` script, so there were no existing tests to run and no harness to add to. Verification was done end to end against a running instance.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

The helper carries a comment explaining why the signature has to go and why only the query is removed.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:
