### PR TITLE
fix(posters): keep the rating poster wherever it is truthful

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -4969,8 +4969,10 @@ addon.get("/stremio/:userUUID/catalog/:type/:id{/:extra}.json", async function (
         const ids = extractIdsFromMeta(meta);
         const rowIsAnime = (meta.type || '') === 'anime' || meta.isAnime === true
           || /^(kitsu|mal|anilist|anidb):/i.test(String(meta.id || ''));
+        const rowSkipsRatingPoster = rowIsAnime
+          && !require('./utils/parseProps').animeRatingPosterKeyIsUnique(ids);
         const type = meta.type || actualType;
-        if (posterPattern && !rowIsAnime && (!isUpNextCatalog || upNextUsesShowPoster)) {
+        if (posterPattern && !rowSkipsRatingPoster && (!isUpNextCatalog || upNextUsesShowPoster)) {
           if (proxyApiKey) {
             const proxyId = ids.imdbId || (ids.tmdbId ? `tmdb:${ids.tmdbId}` : (ids.tvdbId ? `tvdb:${ids.tvdbId}` : null));
             if (proxyId) {
@@ -5150,8 +5152,12 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
       // poster, while kitsu:14095, which has no mapping, kept its own and looked right.
       const isAnimeMeta = metaType === 'anime' || result.meta.isAnime === true
         || /^(kitsu|mal|anilist|anidb):/i.test(String(result.meta.id || ''));
+      // An anime keeps its rating poster when the id it would be keyed on is its own
+      // rather than the whole franchise's; see animeRatingPosterKeyIsUnique.
+      const skipRatingPoster = isAnimeMeta
+        && !require('./utils/parseProps').animeRatingPosterKeyIsUnique(ids);
       // Apply poster pattern unless enableRatingPostersForLibrary is explicitly disabled
-      if (config.enableRatingPostersForLibrary !== false && !isAnimeMeta) {
+      if (config.enableRatingPostersForLibrary !== false && !skipRatingPoster) {
         const metaPosterPattern = resolvePosterPattern(config);
         if (metaPosterPattern) {
           const proxyApiKey = config.usePosterProxy ? getPosterRatingApiKey(config) : null;

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -4967,8 +4967,10 @@ addon.get("/stremio/:userUUID/catalog/:type/:id{/:extra}.json", async function (
       const proxyApiKey = config.usePosterProxy ? getPosterRatingApiKey(config) : null;
       for (const meta of responseData.metas) {
         const ids = extractIdsFromMeta(meta);
+        const rowIsAnime = (meta.type || '') === 'anime' || meta.isAnime === true
+          || /^(kitsu|mal|anilist|anidb):/i.test(String(meta.id || ''));
         const type = meta.type || actualType;
-        if (posterPattern && (!isUpNextCatalog || upNextUsesShowPoster)) {
+        if (posterPattern && !rowIsAnime && (!isUpNextCatalog || upNextUsesShowPoster)) {
           if (proxyApiKey) {
             const proxyId = ids.imdbId || (ids.tmdbId ? `tmdb:${ids.tmdbId}` : (ids.tvdbId ? `tvdb:${ids.tvdbId}` : null));
             if (proxyId) {
@@ -5142,8 +5144,14 @@ addon.get("/stremio/:userUUID/meta/:type/:id.json", async function (req, res) {
       const { resolveCustomArtUrl, resolvePosterPattern, resolveThumbnailPattern, getPosterRatingApiKey } = require('./utils/parseProps');
       const ids = extractIdsFromMeta(result.meta);
       const metaType = result.meta.type || type;
+      // An anime franchise is one title on imdb/tmdb/tvdb and many entries on Kitsu/MAL,
+      // so a poster keyed on the mapped id is the same image for every season. Gintama's
+      // kitsu:818, 5971, 7253 and 12553 all map to tt0988818 and all resolved to one
+      // poster, while kitsu:14095, which has no mapping, kept its own and looked right.
+      const isAnimeMeta = metaType === 'anime' || result.meta.isAnime === true
+        || /^(kitsu|mal|anilist|anidb):/i.test(String(result.meta.id || ''));
       // Apply poster pattern unless enableRatingPostersForLibrary is explicitly disabled
-      if (config.enableRatingPostersForLibrary !== false) {
+      if (config.enableRatingPostersForLibrary !== false && !isAnimeMeta) {
         const metaPosterPattern = resolvePosterPattern(config);
         if (metaPosterPattern) {
           const proxyApiKey = config.usePosterProxy ? getPosterRatingApiKey(config) : null;

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -2841,25 +2841,12 @@ async function buildAnimeResponse(stremioId, malData, language, characterData, e
     // Use AniList poster if available and configured
     let finalPosterUrl = enrichmentData.bestPosterUrl || posterUrl; 
     const _rawPosterUrl = finalPosterUrl;
-    // Check if poster rating is enabled (RPDB or Top Poster API)
-    if (Utils.isPosterRatingEnabled(config) && mapping && stremioType !== 'movie') {
-      const tvdbId = mapping.tvdbId;
-      const tmdbId = mapping.tmdbId;
-      const imdbId = mapping.imdbId;
-      let proxyId = null;
-      let proxyType = stremioType;
-
-      if (tvdbId) {
-        proxyId = `tvdb:${tvdbId}`;
-      } else if (tmdbId || imdbId) {
-        proxyId = tmdbId ? `tmdb:${tmdbId}` : `imdb:${imdbId}`; 
-      }
-
-      if (proxyId) {
-        finalPosterUrl = Utils.buildPosterProxyUrl(host, proxyType, proxyId, posterUrl, language, config);
-      logger.debug(`[buildAnimeResponse] Constructed Poster Rating Proxy URL: ${finalPosterUrl}`);
-      }
-    }
+    // The rating poster is deliberately not applied here. Anime series map many-to-one
+    // onto their tvdb/tmdb/imdb id - a franchise is a single title over there and many
+    // Kitsu/MAL entries over here - so keying the poster on the mapped id handed every
+    // season of a franchise the same image, and the entry's own artwork is the only
+    // thing that tells them apart. Anime movies never reached this branch, so no poster
+    // that previously carried a rating loses one.
     
     
     // Process episodes while API calls are running

--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -2841,12 +2841,15 @@ async function buildAnimeResponse(stremioId, malData, language, characterData, e
     // Use AniList poster if available and configured
     let finalPosterUrl = enrichmentData.bestPosterUrl || posterUrl; 
     const _rawPosterUrl = finalPosterUrl;
-    // The rating poster is deliberately not applied here. Anime series map many-to-one
-    // onto their tvdb/tmdb/imdb id - a franchise is a single title over there and many
-    // Kitsu/MAL entries over here - so keying the poster on the mapped id handed every
-    // season of a franchise the same image, and the entry's own artwork is the only
-    // thing that tells them apart. Anime movies never reached this branch, so no poster
-    // that previously carried a rating loses one.
+    // Only key the rating poster on an id this entry does not share with the rest of its
+    // franchise; see Utils.animeRatingPosterKeyIsUnique.
+    if (Utils.isPosterRatingEnabled(config) && mapping && stremioType !== 'movie'
+        && Utils.animeRatingPosterKeyIsUnique(mapping)) {
+      const proxyId = mapping.tmdbId ? `tmdb:${mapping.tmdbId}` : (mapping.imdbId ? `imdb:${mapping.imdbId}` : null);
+      if (proxyId) {
+        finalPosterUrl = Utils.buildPosterProxyUrl(host, stremioType, proxyId, posterUrl, language, config);
+      }
+    }
     
     
     // Process episodes while API calls are running

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -314,6 +314,61 @@ function getPosterRatingApiKey(config) {
  * we use direct URL and let Stremio handle it. For permanent errors (404, 401), 
  * Top Poster API returns proper codes that Stremio can handle.
  */
+/**
+ * Whether this entry may wear a rating poster.
+ *
+ * The rating providers only know imdb and tmdb ids, and an anime franchise is a single
+ * title there and many entries on Kitsu/MAL, so keying on a shared id hands every
+ * season the same poster. The anime-list mapping records which entries claim an id, so
+ * ask it rather than assume.
+ *
+ * All three indexes are consulted and the longest claimant list wins, because their
+ * coverage differs sharply - roughly 4400 tvdb and 4200 tmdb mappings against 1700 imdb
+ * ones. Gintama is why that matters: tt0988818 is absent from the imdb index and looks
+ * unique, while tmdb 57041 and tvdb 79895 each report thirteen entries.
+ *
+ * An id claimed once is the entry's own and is always safe. An id claimed by several
+ * belongs to the franchise, and exactly one entry may wear it: the start of the first
+ * season, which is what the provider's artwork actually depicts. Every other entry
+ * keeps its own poster, so no two entries can end up showing the same image while the
+ * badge is still preserved wherever it is truthful.
+ */
+function animeRatingPosterKeyIsUnique(ids) {
+  try {
+    const mapper = require('../lib/anime-list-mapper');
+    if (!mapper?.isInitialized?.()) return false;
+    const imdbId = ids?.imdbId || ids?.imdb_id;
+    const tmdbId = ids?.tmdbId || ids?.tmdb_id;
+    const tvdbId = ids?.tvdbId || ids?.tvdb_id;
+    const anidbId = parseInt(ids?.anidbId || ids?.anidb_id, 10);
+
+    let claimants = [];
+    for (const list of [
+      imdbId ? mapper.getAnimeByImdbId(imdbId) : null,
+      tmdbId ? mapper.getAnimeByTmdbId(tmdbId) : null,
+      tvdbId ? mapper.getAnimeByTvdbId(tvdbId) : null,
+    ]) {
+      if (Array.isArray(list) && list.length > claimants.length) claimants = list;
+    }
+    if (claimants.length <= 1) return true;
+    if (!Number.isFinite(anidbId)) return false;
+
+    const rank = (entry) => [
+      entry?.$?.defaulttvdbseason === '1' ? 0 : 1,
+      parseInt(entry?.$?.episodeoffset, 10) || 0,
+      parseInt(entry?.$?.anidbid, 10) || 0,
+    ];
+    const primary = claimants.slice().sort((x, y) => {
+      const a = rank(x), b = rank(y);
+      return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+    })[0];
+    return parseInt(primary?.$?.anidbid, 10) === anidbId;
+  } catch {
+    // Mapping unavailable: a wrong poster is worse than a missing badge, so decline.
+    return false;
+  }
+}
+
 function buildPosterProxyUrl(host, type, proxyId, fallback, language, config) {
   const provider = config.posterRatingProvider || 'none';
   const apiKey = getPosterRatingApiKey(config);
@@ -3493,6 +3548,7 @@ module.exports = {
   resolveProxyRatingPosterUrl,
   getPosterRatingApiKey,
   buildPosterProxyUrl,
+  animeRatingPosterKeyIsUnique,
   isPosterRatingEnabled,
   getDefaultPosterPattern,
   getDefaultThumbnailPattern,
@@ -3657,12 +3713,14 @@ async function getAnimePosterUrl(malId, mapping, stremioType, config, language, 
     }
   }
   
-  // The rating poster is deliberately not applied to anime. A franchise is one title
-  // on imdb/tmdb/tvdb and many entries on Kitsu/MAL, so keying the poster on the mapped
-  // id handed every season of a franchise the same image - Gintama's kitsu:818, 5971,
-  // 7253 and 12553 all map to tt0988818 - while an entry with no mapping kept its own
-  // artwork and looked correct. The entry's own poster is the only thing that tells the
-  // seasons apart, so it is kept.
+  // Only key the rating poster on an id this entry does not share with the rest of its
+  // franchise; see animeRatingPosterKeyIsUnique.
+  if (isPosterRatingEnabled(config) && animeRatingPosterKeyIsUnique({ imdbId, tmdbId, tvdbId, anidbId: mapping?.anidbId })) {
+    const proxyId = (imdbId ? `${imdbId}` : (tmdbId ? `tmdb:${tmdbId}` : null));
+    if (proxyId) {
+      finalPosterUrl = buildPosterProxyUrl(host, stremioType, proxyId, finalPosterUrl, language, config);
+    }
+  }
 
   return finalPosterUrl;
 }

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -3657,14 +3657,12 @@ async function getAnimePosterUrl(malId, mapping, stremioType, config, language, 
     }
   }
   
-  // Check if poster rating is enabled (RPDB or Top Poster API)
-  if (isPosterRatingEnabled(config)) {
-    const proxyId = (imdbId ? `${imdbId}` : (tmdbId ? `tmdb:${tmdbId}` : tvdbId ? `tvdb:${tvdbId}` : null));
-
-    if (proxyId) {
-      finalPosterUrl = buildPosterProxyUrl(host, stremioType, proxyId, finalPosterUrl, language, config);
-    }
-  }
+  // The rating poster is deliberately not applied to anime. A franchise is one title
+  // on imdb/tmdb/tvdb and many entries on Kitsu/MAL, so keying the poster on the mapped
+  // id handed every season of a franchise the same image - Gintama's kitsu:818, 5971,
+  // 7253 and 12553 all map to tt0988818 - while an entry with no mapping kept its own
+  // artwork and looked correct. The entry's own poster is the only thing that tells the
+  // seasons apart, so it is kept.
 
   return finalPosterUrl;
 }


### PR DESCRIPTION
## Summary

An anime franchise is a single title on imdb/tmdb/tvdb and many entries on Kitsu and MAL, so keying the rating poster on the mapped id hands every season the same image. Gintama's `kitsu:818`, `5971`, `7253` and `12553` all map to `tt0988818` and all resolved to `proxy/poster/series/tt0988818`, while `kitsu:14095`, which has no mapping, kept its own artwork and looked correct — which is why the fault appeared to strike at random. An id claimed once is the entry's own and is always safe to key on. An id claimed by several belongs to the franchise, and exactly one entry may wear it — the start of the first season, which is what the provider's artwork actually depicts. Every other entry keeps its own poster, so no two entries can show the same image while the badge survives wherever it is truthful.

## Linked issue

Closes #703

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests only
- [ ] Documentation only
- [ ] CI / tooling

## Why this approach

#703 listed three options: re-key on the Kitsu/MAL id, skip the overlay when the id is shared, or make it disableable per type.

Re-keying does not work. I checked what the provider actually serves:

```
imdb/poster/tt0988818.jpg   HTTP 200
tmdb/poster/33227.jpg       HTTP 200
mal/poster/918.jpg          HTTP 404
kitsu/poster/818.jpg        HTTP 404
anilist/poster/918.jpg      HTTP 404
```

Only imdb and tmdb are served, so a Kitsu-keyed lookup would miss every time and fall through to the `fallback` parameter — the same outcome plus a wasted request.

Dropping the rating poster for all anime works but is too blunt: most anime map one-to-one and their badge was never wrong. So this detects sharing instead. `anime-list-mapper` already indexes which entries claim an id, and exposes `getAnimeByImdbId` / `getAnimeByTmdbId` / `getAnimeByTvdbId` returning the claimant list — the information needed is already in memory.

All three indexes are consulted and the longest claimant list wins, because their coverage differs sharply: roughly 4400 tvdb and 4200 tmdb mappings against 1700 imdb ones. Gintama is why that matters — `tt0988818` is **absent** from the imdb index and looks unique, while tmdb 57041 and tvdb 79895 each report thirteen entries. Reading the imdb miss as "unique" would hand all thirteen the same poster again.

The rating poster is applied to anime in four places — `buildAnimeResponse`, `getAnimePosterUrl`, and the poster pattern block on both the meta route and the catalog route in `index` — and all four key on the same shared id. Fixing fewer than four leaves the collision reachable, which is how my first two attempts at this missed. Anime movies never reached the two builder paths, so no poster that previously carried a rating loses one.

Tradeoff: a non-primary entry of a franchise no longer carries a badge, because the only poster the provider has for it depicts a different season. Half the rows on my board still carry one, and none of them are wrong.

## Testing

Against a live config on 2.16.5, `posterRatingProvider: "top"`, `usePosterProxy: true`.

Before — four of five entries collapse onto one key:

```
kitsu:818     tt0988818   proxy/poster/series/tt0988818
kitsu:5971    tt0988818   proxy/poster/series/tt0988818
kitsu:7253    tt0988818   proxy/poster/series/tt0988818
kitsu:12553   tt0988818   proxy/poster/series/tt0988818
kitsu:14095   (none)      poster/media.kitsu.app/.../14095/original.png   <- correct
```

After — the first season keeps the badge, the sequels keep their own artwork:

```
kitsu:818     Gintama                     RATING poster (primary entry for the id)
kitsu:5971    Gintama Season 2            own artwork
kitsu:7253    Gintama: Enchousen          own artwork
kitsu:12553   Gintama Season 5            own artwork
kitsu:14095   Gintama.: Silver Soul Arc   own artwork
kitsu:43683   Gintama: The Final          RATING poster (claimed once, tt10766468)
```

Swept the six anime catalogs on my board afterwards:

```
mal.top_anime      25 rows,  9 with rating poster
anilist.trending   50 rows, 31 with rating poster
mal.airing         22 rows, 11 with rating poster
mal.seasons        23 rows, 10 with rating poster
mal.upcoming       22 rows,  1 with rating poster
mal.season_top_new 24 rows, 21 with rating poster

TOTAL 166 rows, 83 with a rating poster, 0 cases of two different titles sharing a poster
```

No regressions: `catalog/series/tmdb.top` rows still carry their rating-proxy posters and their `TV-14` / `TV-MA` / `TV-14` chips, and `meta/series/tt0131179` is unchanged at `videos=1296 seasons=34 S29E10=true`.

- [ ] I ran existing tests relevant to this change.
- [ ] I added or updated tests where needed.
- [x] No tests were needed, and I explained why.

The repository has no test suite or `test` script, so there were no existing tests to run and no harness to add to. Verification was done end to end against a running instance.

## Documentation

- [x] I updated documentation or comments where needed.
- [ ] No documentation updates were needed.

Each of the four sites carries a comment naming the reason and the Gintama case, so the omission is not mistaken later for something that was forgotten.

## Author checklist

- [x] This PR is focused on one concern.
- [x] This PR is reasonably small and reviewable.
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I can explain every code change in this PR.
- [x] I will respond to review feedback myself.

## AI usage disclosure

- [ ] No AI tools were used.
- [ ] AI tools were used for part of this PR, and I personally reviewed and verified all changes.

If AI tools were used, briefly describe how:
