### PR TITLE
fix(configure): reseed catalog rename dialog when it opens

### DIFF
--- a/configure/src/components/sections/CatalogsSettings.tsx
+++ b/configure/src/components/sections/CatalogsSettings.tsx
@@ -2584,6 +2584,13 @@ const MergedCatalogCard = ({
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [newName, setNewName] = useState(catalog.name);
   const [newType, setNewType] = useState(catalog.displayType || catalog.type);
+  // Rows are keyed by id+type, so loading a saved config reuses this instance
+  // and leaves the dialog fields on the pre-load values. Reseed on open.
+  useEffect(() => {
+    if (!showEditDialog) return;
+    setNewName(catalog.name);
+    setNewType(catalog.displayType || catalog.type);
+  }, [showEditDialog, catalog.name, catalog.displayType, catalog.type]);
   const [showSettings, setShowSettings] = useState(false);
   const [settingsMergeMode, setSettingsMergeMode] = useState<'interleaved' | 'sequential' | 'alternating'>(catalog.metadata?.mergeMode || 'interleaved');
 
@@ -3003,6 +3010,13 @@ const SortableCatalogItem = React.memo(({ catalog, onEditDiscover, onCustomize, 
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [newName, setNewName] = useState(catalog.name);
   const [newType, setNewType] = useState(catalog.displayType || catalog.type);
+  // Rows are keyed by id+type, so loading a saved config reuses this instance
+  // and leaves the dialog fields on the pre-load values. Reseed on open.
+  useEffect(() => {
+    if (!showEditDialog) return;
+    setNewName(catalog.name);
+    setNewType(catalog.displayType || catalog.type);
+  }, [showEditDialog, catalog.name, catalog.displayType, catalog.type]);
   const [showSettings, setShowSettings] = useState(false);
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
   const SettingsDialog = resolveSettingsDialog(catalog);


### PR DESCRIPTION
### Problem

The **Edit Catalog** dialog (the pencil next to a catalog name) can show the name/type a catalog had *before* the catalogs array was replaced — after loading a saved configuration, or after importing a setup.

`newName` / `newType` are seeded from the `catalog` prop with `useState`, so they only ever hold the values that existed when that row first mounted:

```tsx
const [newName, setNewName] = useState(catalog.name);
const [newType, setNewType] = useState(catalog.displayType || catalog.type);
```

Rows are keyed by `` `${catalog.id}-${catalog.type}` ``, so loading a config replaces the catalogs array while React reuses the same row instances. The list re-renders with the new names; the dialog does not.

Only `handleEditCancel` (and the empty-input branch of save) reseeds from the prop, which is why cancelling and reopening shows the correct value — the workaround, and the tell.

**This can lose data:** opening the pencil after a config load and pressing **Save** without touching anything writes the stale name straight back into the config.

`MergedCatalogCard` has the identical bug.

### Repro

1. Rename a catalog (pencil → Save).
2. Import a setup / load a saved config that gives the same catalog a different name.
3. The row shows the imported name; open the pencil → it shows the name from step 1.
4. Cancel, reopen → now correct.

![Stale name in the Edit Catalog dialog](https://raw.githubusercontent.com/Rockapela/aiometadata/pr-assets/stale-rename-dialog.gif)

### Fix

Reseed both fields whenever the dialog opens, in both components. `npx tsc -p tsconfig.app.json --noEmit` is clean.
